### PR TITLE
Theme preview: Create preview page and show wp-themes.com preview

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -11,6 +11,7 @@ require_once( __DIR__ . '/src/child-theme-notice/index.php' );
 require_once( __DIR__ . '/src/ratings-bars/index.php' );
 require_once( __DIR__ . '/src/ratings-stars/index.php' );
 require_once( __DIR__ . '/src/theme-patterns/index.php' );
+require_once( __DIR__ . '/src/theme-previewer/index.php' );
 
 /**
  * Actions and filters.

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -27,7 +27,20 @@ add_action( 'single_template_hierarchy', __NAMESPACE__ . '\load_theme_preview' )
 // Remove filters added by plugin.
 remove_filter( 'post_thumbnail_html', 'wporg_themes_post_thumbnail_html', 10, 5 );
 
-add_filter( 'show_admin_bar', '__return_false', 2000 );
+// Hide admin bar on preview pages.
+add_filter(
+	'show_admin_bar',
+	function( $should_show ) {
+		global $wp_query;
+
+		if ( isset( $wp_query->query_vars['view'] ) ) {
+			return false;
+		}
+
+		return $should_show;
+	},
+	2000
+);
 
 /**
  * Temporary fix for permission problem during local install.

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -16,12 +16,17 @@ require_once( __DIR__ . '/src/theme-patterns/index.php' );
  * Actions and filters.
  */
 add_action( 'init', __NAMESPACE__ . '\fix_term_imports' );
+add_action( 'init', __NAMESPACE__ . '\add_preview_endpoint' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
-add_filter( 'frontpage_template_hierarchy', __NAMESPACE__ . '\use_archive_template_paged' );
 add_filter( 'post_thumbnail_html', __NAMESPACE__ . '\post_thumbnail_html', 10, 5 );
+add_action( 'body_class', __NAMESPACE__ . '\add_extra_body_class' );
+add_filter( 'frontpage_template_hierarchy', __NAMESPACE__ . '\use_archive_template_paged' );
+add_action( 'single_template_hierarchy', __NAMESPACE__ . '\load_theme_preview' );
 
 // Remove filters added by plugin.
 remove_filter( 'post_thumbnail_html', 'wporg_themes_post_thumbnail_html', 10, 5 );
+
+add_filter( 'show_admin_bar', '__return_false', 2000 );
 
 /**
  * Temporary fix for permission problem during local install.
@@ -30,6 +35,13 @@ function fix_term_imports() {
 	if ( defined( 'WP_CLI' ) ) {
 		remove_filter( 'pre_insert_term', 'wporg_themes_pre_insert_term' );
 	}
+}
+
+/**
+ * Set up the `view` endpoint.
+ */
+function add_preview_endpoint() {
+	add_rewrite_endpoint( 'preview', EP_PERMALINK, 'view' );
 }
 
 /**
@@ -45,18 +57,6 @@ function enqueue_assets() {
 		array( 'wporg-parent-2021-style', 'wporg-global-fonts' ),
 		filemtime( __DIR__ . '/style.css' )
 	);
-}
-
-/**
- * Switch to the archive.html template on paged requests.
- *
- * @param string[] $templates A list of template candidates, in descending order of priority.
- */
-function use_archive_template_paged( $templates ) {
-	if ( is_paged() ) {
-		array_unshift( $templates, 'archive.html' );
-	}
-	return $templates;
 }
 
 /**
@@ -96,6 +96,48 @@ function post_thumbnail_html( $html, $post_id, $post_thumbnail_id, $size, $attr 
 	}
 
 	return $html;
+}
+
+/**
+ * Add some custom classes to `body`.
+ *
+ * @param string[] $classes   An array of body class names.
+ */
+function add_extra_body_class( $classes ) {
+	global $wp_query;
+
+	if ( isset( $wp_query->query_vars['view'] ) ) {
+		$classes[] = 'wporg-theme-preview';
+	}
+
+	return $classes;
+}
+
+/**
+ * Switch to the archive.html template on paged requests.
+ *
+ * @param string[] $templates A list of template candidates, in descending order of priority.
+ */
+function use_archive_template_paged( $templates ) {
+	if ( is_paged() ) {
+		array_unshift( $templates, 'archive.html' );
+	}
+	return $templates;
+}
+
+/**
+ * If this is the `view` query, use preview template.
+ *
+ * @param string[] $templates A list of template candidates, in descending order of priority.
+ */
+function load_theme_preview( $templates ) {
+	global $wp_query;
+
+	if ( isset( $wp_query->query_vars['view'] ) ) {
+		return [ 'preview.html' ];
+	}
+
+	return $templates;
 }
 
 /**

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -303,3 +303,30 @@ function get_theme_patterns( $theme_name ) {
 
 	return $patterns;
 }
+
+/**
+ * Get the list of style variations from wp-themes.com API.
+ */
+function get_theme_style_variations( $theme_name ) {
+	$cache_key = 'wporg-themes-' . $theme_name . '-style-variations';
+	$styles = get_transient( $cache_key );
+
+	if ( false === $styles ) {
+		$url = 'https://wp-themes.com/' . $theme_name . '/';
+		$url = add_query_arg( 'rest_route', '/wporg-styles/v1/variations', $url );
+		$response = wp_remote_get( $url );
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			// Set a short timeout to avoid hammering the API during outages.
+			set_transient( $cache_key, [], 0.5 * MINUTE_IN_SECONDS );
+			return [];
+		}
+
+		// This is decoded twice because the response is a quoted JSON string.
+		// The first decode parses out to JSON, the second parses out to an object.
+		$styles = json_decode( json_decode( wp_remote_retrieve_body( $response ) ) );
+
+		set_transient( $cache_key, $styles, HOUR_IN_SECONDS );
+	}
+
+	return $styles;
+}

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -276,3 +276,30 @@ function wporg_themes_get_feature_list( $include = 'active', $subset = '' ) {
 
 	return $features;
 }
+
+/**
+ * Get the list of patterns from wp-themes.com API.
+ */
+function get_theme_patterns( $theme_name ) {
+	$cache_key = 'wporg-themes-' . $theme_name . '-patterns';
+	$patterns = get_transient( $cache_key );
+
+	if ( false === $patterns ) {
+		$url = 'https://wp-themes.com/' . $theme_name . '/';
+		$url = add_query_arg( 'rest_route', '/wporg-patterns/v1/patterns', $url );
+		$response = wp_remote_get( $url );
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			// Set a short timeout to avoid hammering the API during outages.
+			set_transient( $cache_key, [], 0.5 * MINUTE_IN_SECONDS );
+			return [];
+		}
+
+		// This is decoded twice because the response is a quoted JSON string.
+		// The first decode parses out to JSON, the second parses out to an object.
+		$patterns = json_decode( json_decode( wp_remote_retrieve_body( $response ) ) );
+
+		set_transient( $cache_key, $patterns, HOUR_IN_SECONDS );
+	}
+
+	return $patterns;
+}

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-bindings.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-bindings.php
@@ -95,7 +95,7 @@ function get_meta_block_value( $args, $block ) {
 			}
 			return '';
 		case 'preview-url':
-			return esc_url( $theme->preview_url );
+			return esc_url( untrailingslashit( get_permalink( $p ) ) . '/preview/' );
 		case 'download-url':
 			return esc_url( $theme->download_link );
 		case 'download-text':

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-bindings.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-bindings.php
@@ -98,6 +98,8 @@ function get_meta_block_value( $args, $block ) {
 			return esc_url( $theme->preview_url );
 		case 'download-url':
 			return esc_url( $theme->download_link );
+		case 'download-text':
+			return esc_html__( 'Download', 'wporg-themes' );
 		case 'ratings-link':
 			return sprintf(
 				'<a href="%s">%s</a>',
@@ -152,5 +154,12 @@ function get_meta_block_value( $args, $block ) {
 				esc_url( "https://themes.trac.wordpress.org/query?keywords=~theme-{$theme->slug}" ),
 				__( 'Trac Tickets', 'wporg-themes' )
 			);
+		case 'zip-name':
+			$filename = basename( $theme->download_link );
+			return esc_html( $filename );
+		case 'preview-back-url':
+			return get_permalink();
+		case 'preview-back-text':
+			return __( '← Back', 'wporg-themes' );
 	}
 }

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/block.json
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/block.json
@@ -8,6 +8,12 @@
 	"icon": "",
 	"description": "A list of patterns provided by this theme (with screenshots).",
 	"textdomain": "wporg",
+	"attributes": {
+		"showAll": {
+			"type": "boolean",
+			"default": false
+		}
+	},
 	"supports": {
 		"html": false
 	},

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/render.php
@@ -41,11 +41,13 @@ if ( ! $current_post_id ) {
 	return;
 }
 
+$show_all = $attributes['showAll'] ?? false;
+
 $theme_post = get_post( $block->context['postId'] );
 $theme = wporg_themes_theme_information( $theme_post->post_name );
 
 $patterns = get_theme_patterns( $theme_post->post_name );
-$initial_count = 6;
+$initial_count = $show_all ? PHP_INT_MAX : 6;
 
 if ( ! count( $patterns ) ) {
 	return '';

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/render.php
@@ -6,11 +6,19 @@ use function WordPressdotorg\Theme\Theme_Directory_2024\{ get_support_url, get_t
  * Convert a pattern object into a screenshot preview block.
  */
 function get_pattern_preview_block( $pattern, $is_overflow = false ) {
+	$preview_link = add_query_arg( 'pattern_name', $pattern->name, $pattern->preview_base );
+
+	// If the page has a `style_variation` set, pass it through.
+	if ( isset( $_REQUEST['style_variation'] ) ) {
+		$style = sanitize_text_field( wp_unslash( $_REQUEST['style_variation'] ) );
+		$preview_link = add_query_arg( 'style_variation', $style, $preview_link );
+	}
+
 	$args = array(
 		'src' => $pattern->preview_link,
 		// translators: %s pattern name.
 		'alt' => sprintf( __( 'Pattern: %s', 'wporg-themes' ), $pattern->title ),
-		'href' => $pattern->link,
+		'href' => $preview_link,
 		'width' => 275,
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Name comes from API.
 		'viewportWidth' => $pattern->viewportWidth ?? 1200,
@@ -60,6 +68,7 @@ $encoded_state = wp_json_encode( $init_state );
 	<div class="wporg-theme-patterns__grid">
 		<?php
 		foreach ( $patterns as $i => $pattern ) {
+			$pattern->preview_base = untrailingslashit( get_permalink( $theme_post ) ) . '/preview/';
 			echo get_pattern_preview_block( $pattern, $i >= $initial_count ); // phpcs:ignore
 		}
 		?>

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/render.php
@@ -1,6 +1,6 @@
 <?php
 
-use function WordPressdotorg\Theme\Theme_Directory_2024\get_support_url;
+use function WordPressdotorg\Theme\Theme_Directory_2024\{ get_support_url, get_theme_patterns };
 
 /**
  * Convert a pattern object into a screenshot preview block.
@@ -36,20 +36,7 @@ if ( ! $current_post_id ) {
 $theme_post = get_post( $block->context['postId'] );
 $theme = wporg_themes_theme_information( $theme_post->post_name );
 
-$url = 'https://wp-themes.com/' . $theme_post->post_name . '/';
-$url = add_query_arg( 'rest_route', '/wporg-patterns/v1/patterns', $url );
-$response = wp_remote_get( $url );
-if ( is_wp_error( $response ) ) {
-	return;
-}
-
-if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-	return;
-}
-
-// This is decoded twice because the response is a quoted JSON string.
-// The first decode parses out to JSON, the second parses out to an object.
-$patterns = json_decode( json_decode( wp_remote_retrieve_body( $response ) ) );
+$patterns = get_theme_patterns( $theme_post->post_name );
 $initial_count = 6;
 
 if ( ! count( $patterns ) ) {

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/block.json
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/block.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/theme-previewer",
+	"version": "0.1.0",
+	"title": "Theme previewer",
+	"category": "design",
+	"icon": "",
+	"description": "An iframe portal to view the current theme's preview site.",
+	"textdomain": "wporg",
+	"supports": {
+		"html": false
+	},
+	"usesContext": [ "postId", "postType" ],
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php",
+	"viewScriptModule": "file:./view.js"
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/index.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/index.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from '../utils/dynamic-edit';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/index.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Block Name: Theme previewer
+ * Description: An iframe portal to view the current theme's preview site.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Theme_Directory_2024\Theme_Previewer;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Register the block.
+ */
+function init() {
+	register_block_type( dirname( dirname( __DIR__ ) ) . '/build/theme-previewer' );
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
@@ -1,0 +1,96 @@
+<?php
+
+$current_post_id = $block->context['postId'];
+if ( ! $current_post_id ) {
+	return;
+}
+
+$theme_post = get_post( $block->context['postId'] );
+$theme = wporg_themes_theme_information( $theme_post->post_name );
+
+$is_valid_url = isset( $theme->preview_url ) && 'wp-themes.com' === wp_parse_url( $theme->preview_url, PHP_URL_HOST );
+$url = $is_valid_url ? $theme->preview_url : '';
+
+// Get the device size from the query.
+$devices = [ 'desktop', 'tablet', 'mobile' ];
+$device = 'desktop';
+if ( isset( $_REQUEST['device'] ) && in_array( $_REQUEST['device'], $devices ) ) {
+	$device = $_REQUEST['device']; // phpcs:ignore -- exact match to a given string.
+}
+
+$classes = array();
+$notice = '';
+
+if ( ! $is_valid_url ) {
+	$notice = '<!-- wp:wporg/notice {"type":"warning"} -->';
+	$notice .= '<div class="wp-block-wporg-notice is-warning-notice">';
+	$notice .= '<div class="wp-block-wporg-notice__icon"></div>';
+	$notice .= '<div class="wp-block-wporg-notice__content"><p>';
+	$notice .= sprintf(
+		__( 'The preview could not be loaded.', 'wporg-themes' ),
+	);
+	$notice .= '</p></div></div>';
+	$notice .= '<!-- /wp:wporg/notice -->';
+
+	$classes[] = 'has-invalid-preview';
+}
+
+// Initial state to pass to Interactivity API.
+$init_state = [
+	'device' => $device,
+	'isLoaded' => ! $is_valid_url,
+];
+$encoded_state = wp_json_encode( $init_state );
+
+?>
+<div
+	<?php echo get_block_wrapper_attributes( [ 'class' => implode( ' ', $classes ) ] ); // phpcs:ignore ?>
+	data-wp-interactive="wporg/themes/preview"
+	data-wp-context="<?php echo esc_attr( $encoded_state ); ?>"
+	data-wp-class--is-loaded="state.isLoaded"
+>
+	<?php echo do_blocks( $notice ); // phpcs:ignore ?>
+	<?php if ( $is_valid_url ) : ?>
+		<section class="wporg-theme-previewer__controls wp-block-buttons" aria-label="<?php esc_attr_e( 'Preview width', 'wporg-themes' ); ?>">
+			<div class="wp-block-button is-style-toggle is-small">
+				<button
+					class="wp-block-button__link wp-element-button"
+					data-wp-bind--aria-pressed="state.isDeviceDesktop"
+					data-wp-on--click="actions.onDeviceChange"
+					data-device="desktop"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" aria-hidden="true" focusable="false"><path d="M20.5 16h-.7V8c0-1.1-.9-2-2-2H6.2c-1.1 0-2 .9-2 2v8h-.7c-.8 0-1.5.7-1.5 1.5h20c0-.8-.7-1.5-1.5-1.5zM5.7 8c0-.3.2-.5.5-.5h11.6c.3 0 .5.2.5.5v7.6H5.7V8z"></path></svg>
+					<span><?php echo esc_attr_x( 'Wide', 'theme preview size toggle', 'wporg-themes' ); ?></span>
+				</button>
+			</div>
+			<div class="wp-block-button is-style-toggle is-small">
+				<button
+					class="wp-block-button__link wp-element-button"
+					data-wp-bind--aria-pressed="state.isDeviceTablet"
+					data-wp-on--click="actions.onDeviceChange"
+					data-device="tablet"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" aria-hidden="true" focusable="false"><path d="M17 4H7c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 14c0 .3-.2.5-.5.5H7c-.3 0-.5-.2-.5-.5V6c0-.3.2-.5.5-.5h10c.3 0 .5.2.5.5v12zm-7.5-.5h4V16h-4v1.5z"></path></svg>
+					<span><?php echo esc_attr_x( 'Medium', 'theme preview size toggle', 'wporg-themes' ); ?></span>
+				</button>
+			</div>
+			<div class="wp-block-button is-style-toggle is-small">
+				<button
+					class="wp-block-button__link wp-element-button"
+					data-wp-bind--aria-pressed="state.isDeviceMobile"
+					data-wp-on--click="actions.onDeviceChange"
+					data-device="mobile"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" aria-hidden="true" focusable="false"><path d="M15 4H9c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h6c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 14c0 .3-.2.5-.5.5H9c-.3 0-.5-.2-.5-.5V6c0-.3.2-.5.5-.5h6c.3 0 .5.2.5.5v12zm-4.5-.5h2V16h-2v1.5z"></path></svg>
+					<span><?php echo esc_attr_x( 'Narrow', 'theme preview size toggle', 'wporg-themes' ); ?></span>
+				</button>
+			</div>
+		</section>
+		<iframe
+			src="<?php echo esc_url( $url ); ?>"
+			data-wp-style--width="state.iframeWidthCSS"
+			data-wp-style--height="state.iframeHeightCSS"
+			data-wp-on--load="actions.onLoad"
+		/>
+	<?php endif; ?>
+</div>

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
@@ -1,5 +1,7 @@
 <?php
 
+use function WordPressdotorg\Theme\Theme_Directory_2024\get_theme_patterns;
+
 $current_post_id = $block->context['postId'];
 if ( ! $current_post_id ) {
 	return;
@@ -8,8 +10,7 @@ if ( ! $current_post_id ) {
 $theme_post = get_post( $block->context['postId'] );
 $theme = wporg_themes_theme_information( $theme_post->post_name );
 
-$is_valid_url = isset( $theme->preview_url ) && 'wp-themes.com' === wp_parse_url( $theme->preview_url, PHP_URL_HOST );
-$url = $is_valid_url ? $theme->preview_url : '';
+$url = $theme->preview_url ?? '';
 
 // Get the device size from the query.
 $devices = [ 'desktop', 'tablet', 'mobile' ];
@@ -17,6 +18,18 @@ $device = 'desktop';
 if ( isset( $_REQUEST['device'] ) && in_array( $_REQUEST['device'], $devices ) ) {
 	$device = $_REQUEST['device']; // phpcs:ignore -- exact match to a given string.
 }
+
+// Check for any variation or pattern values passed in the query.
+if ( isset( $_REQUEST['pattern_name'] ) ) {
+	$show_pattern = wp_unslash( $_REQUEST['pattern_name'] ); // phpcs:ignore -- exact match to a given string.
+	$patterns = get_theme_patterns( $theme_post->post_name );
+	if ( $patterns ) {
+		$matches = wp_list_filter( $patterns, [ 'name' => $show_pattern ] );
+		$url = $matches ? $matches[0]->link : $url;
+	}
+}
+
+$is_valid_url = $url && 'wp-themes.com' === wp_parse_url( $url, PHP_URL_HOST );
 
 $classes = array();
 $notice = '';
@@ -87,7 +100,7 @@ $encoded_state = wp_json_encode( $init_state );
 			</div>
 		</section>
 		<iframe
-			src="<?php echo esc_url( $url ); ?>"
+			src="<?php echo esc_url_raw( $url ); ?>"
 			data-wp-style--width="state.iframeWidthCSS"
 			data-wp-style--height="state.iframeHeightCSS"
 			data-wp-on--load="actions.onLoad"

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
@@ -1,6 +1,6 @@
 <?php
 
-use function WordPressdotorg\Theme\Theme_Directory_2024\get_theme_patterns;
+use function WordPressdotorg\Theme\Theme_Directory_2024\{ get_theme_patterns, get_theme_style_variations };
 
 $current_post_id = $block->context['postId'];
 if ( ! $current_post_id ) {
@@ -19,13 +19,27 @@ if ( isset( $_REQUEST['device'] ) && in_array( $_REQUEST['device'], $devices ) )
 	$device = $_REQUEST['device']; // phpcs:ignore -- exact match to a given string.
 }
 
-// Check for any variation or pattern values passed in the query.
+// Switch to using the pattern URL if a pattern is requested.
 if ( isset( $_REQUEST['pattern_name'] ) ) {
 	$show_pattern = wp_unslash( $_REQUEST['pattern_name'] ); // phpcs:ignore -- exact match to a given string.
 	$patterns = get_theme_patterns( $theme_post->post_name );
 	if ( $patterns ) {
 		$matches = wp_list_filter( $patterns, [ 'name' => $show_pattern ] );
-		$url = $matches ? $matches[0]->link : $url;
+		if ( $matches ) {
+			$url = current( $matches )->link;
+		}
+	}
+}
+
+// Add the style variation to the URL if one is selected.
+if ( isset( $_REQUEST['style_variation'] ) ) {
+	$show_style = wp_unslash( $_REQUEST['style_variation'] ); // phpcs:ignore -- exact match to a given string.
+	$styles = get_theme_style_variations( $theme_post->post_name );
+	if ( $styles ) {
+		$matches = wp_list_filter( $styles, [ 'title' => $show_style ] );
+		if ( $matches ) {
+			$url = add_query_arg( 'style_variation', $show_style, $url );
+		}
 	}
 }
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/style.scss
@@ -1,0 +1,89 @@
+.wp-block-wporg-theme-previewer {
+	height: 100%;
+	width: 100%;
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	background-color: var(--wp--preset--color--charcoal-0);
+
+	&:not(.has-invalid-preview) {
+		justify-content: center;
+	}
+
+	iframe {
+		display: block;
+		z-index: 1;
+		margin: 0 auto;
+		// Space for the mobile toggles.
+		padding-bottom: 60px;
+		height: 100%;
+		width: 100%;
+		border: none;
+	}
+
+	&.is-loaded iframe {
+		transition: width 0.3s ease-out, height 0.3s ease-out;
+
+		@media (prefers-reduced-motion) {
+			transition: none;
+		}
+	}
+
+	&:not(.is-loaded)::before {
+		content: "";
+		display: inline-block;
+		box-sizing: border-box;
+		position: absolute;
+		left: calc(50% - 8px);
+		top: calc(50% - 8px);
+		z-index: 0;
+		height: 16px;
+		width: 16px;
+		border: 1.5px solid;
+		border-color:
+			var(--wp--preset--color--charcoal-4)
+			var(--wp--preset--color--charcoal-4)
+			var(--wp--preset--color--blueberry-3);
+		border-radius: 50%;
+		animation: rotate-360 1.4s linear infinite;
+	}
+}
+
+.wporg-theme-previewer__controls {
+	position: absolute;
+	z-index: 10;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	display: flex;
+	justify-content: center;
+	gap: 0;
+	padding: var(--wp--preset--spacing--10);
+	background-color: var(--wp--preset--color--white);
+	border-top: 1px solid var(--wp--preset--color--black-opacity-15);
+
+	.wp-element-button {
+		--wp--custom--button--spacing--padding--top: 1px !important;
+		--wp--custom--button--spacing--padding--bottom: 1px !important;
+		--wp--custom--button--spacing--padding--left: 8px !important;
+
+		display: flex !important;
+		gap: 4px;
+		align-items: center;
+		border-color: transparent !important;
+
+		svg {
+			fill: currentColor !important;
+		}
+	}
+}
+
+@keyframes rotate-360 {
+	0% {
+		transform: rotate(0deg);
+	}
+
+	100% {
+		transform: rotate(360deg);
+	}
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/view.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { getContext, getElement, store } from '@wordpress/interactivity';
+
+store( 'wporg/themes/preview', {
+	state: {
+		get iframeWidthCSS() {
+			const { device } = getContext();
+			if ( device === 'mobile' ) {
+				return '360px';
+			} else if ( device === 'tablet' ) {
+				return '768px';
+			}
+			return '100%';
+		},
+		get iframeHeightCSS() {
+			const { device } = getContext();
+			if ( device === 'mobile' ) {
+				return '800px';
+			} else if ( device === 'tablet' ) {
+				return '1024px';
+			}
+			return '100%';
+		},
+		get isDeviceDesktop() {
+			return getContext().device === 'desktop';
+		},
+		get isDeviceTablet() {
+			return getContext().device === 'tablet';
+		},
+		get isDeviceMobile() {
+			return getContext().device === 'mobile';
+		},
+		get isLoaded() {
+			return getContext().isLoaded;
+		},
+	},
+	actions: {
+		onDeviceChange() {
+			const { ref } = getElement();
+			const context = getContext();
+			const { device = '' } = ref.dataset;
+
+			if ( [ 'desktop', 'tablet', 'mobile' ].includes( device ) ) {
+				context.device = device;
+				const url = new URL( window.location.href );
+				url.searchParams.set( 'device', device );
+				window.history.replaceState( {}, '', url.href );
+			}
+		},
+		onLoad() {
+			const context = getContext();
+			context.isLoaded = true;
+		},
+	},
+} );

--- a/source/wp-content/themes/wporg-themes-2024/style.css
+++ b/source/wp-content/themes/wporg-themes-2024/style.css
@@ -50,5 +50,9 @@
 }
 
 :where(body.wporg-theme-preview) .wporg-theme-preview__download {
-	margin-top: auto;
+	top: auto;
+	bottom: 0;
+	background-color: inherit;
+	margin-inline: calc(-1 * var(--wp--preset--spacing--20));
+	padding-inline: var(--wp--preset--spacing--20);
 }

--- a/source/wp-content/themes/wporg-themes-2024/style.css
+++ b/source/wp-content/themes/wporg-themes-2024/style.css
@@ -56,3 +56,20 @@
 	margin-inline: calc(-1 * var(--wp--preset--spacing--20));
 	padding-inline: var(--wp--preset--spacing--20);
 }
+
+:where(body.wporg-theme-preview) .wporg-theme-patterns__grid {
+	grid-template-columns: repeat(2, 1fr);
+	gap: var(--wp--preset--spacing--10);
+}
+
+:where(body.wporg-theme-preview) .wp-block-wporg-screenshot-preview:where(.is-linked-image):hover {
+	border-color: var(--wp--preset--color--blueberry-2);
+	border-width: 1.5px;
+}
+
+:where(body.wporg-theme-preview) .wp-block-wporg-screenshot-preview:where(.is-linked-image):focus-within {
+	border-color: var(--wp--preset--color--blueberry-1);
+	border-width: 1.5px;
+	outline-color: var(--wp--preset--color--white);
+	outline-offset: 0;
+}

--- a/source/wp-content/themes/wporg-themes-2024/style.css
+++ b/source/wp-content/themes/wporg-themes-2024/style.css
@@ -26,3 +26,29 @@
 	border-radius: 2px;
 	box-shadow: 0 0 0 1.5px var(--wp--custom--link--color--text);
 }
+
+:where(main) a:where(:not(.wp-element-button)):focus,
+:where(main) button:where(:not([class*="wp-block-button"])):focus {
+	outline: none;
+	border-radius: 2px;
+	box-shadow: 0 0 0 1.5px var(--wp--custom--link--color--text);
+}
+
+:where(body.wporg-theme-preview) .wporg-theme-preview__container {
+	height: 100vh;
+}
+
+:where(body.wporg-theme-preview) .wporg-theme-preview__container > .wp-block-column {
+	display: flex;
+	flex-direction: column;
+	overflow: auto;
+}
+
+:where(body.wporg-theme-preview) .wp-block-column.has-charcoal-1-background-color {
+	/* Set the link color so that the focus outline is visible. */
+	--wp--custom--link--color--text: var(--wp--preset--color--blueberry-3);
+}
+
+:where(body.wporg-theme-preview) .wporg-theme-preview__download {
+	margin-top: auto;
+}

--- a/source/wp-content/themes/wporg-themes-2024/templates/preview.html
+++ b/source/wp-content/themes/wporg-themes-2024/templates/preview.html
@@ -1,0 +1,61 @@
+<!-- wp:group {"tagName":"main","layout":{"type":"default"},"className":"entry-content","style":{"spacing":{"blockGap":"0px"}}} -->
+<main class="wp-block-group entry-content">
+	<!-- wp:columns {"align":"full","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}},"className":"wporg-theme-preview__container"} -->
+	<div class="wp-block-columns alignfull wporg-theme-preview__container">
+		<!-- wp:column {"width":"300px","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-3"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}},"backgroundColor":"charcoal-1","textColor":"white"} -->
+		<div class="wp-block-column has-white-color has-charcoal-1-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20);flex-basis:300px">
+			<!-- wp:buttons {"className":"wporg-theme-preview__back"} -->
+			<div class="wp-block-buttons wporg-theme-preview__back">
+				<!-- wp:button {"className":"is-style-outline-on-dark is-small","metadata":{"bindings":{"url":{"source":"wporg-themes/meta","args":{"key":"preview-back-url"}},"text":{"source":"wporg-themes/meta","args":{"key":"preview-back-text"}}}}} -->
+				<div class="wp-block-button is-style-outline-on-dark is-small"><a class="wp-block-button__link wp-element-button">← Back</a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+		
+			<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+			<div class="wp-block-group">
+				<!-- wp:post-title {"level":1,"fontSize":"heading-5"} /-->
+			
+				<!-- wp:post-author-name {"isLink":true} /-->
+			</div>
+			<!-- /wp:group -->
+		
+			<!-- wp:post-excerpt {"fontSize":"small"} /-->
+		
+			<!-- wp:paragraph -->
+			<p>[style variations]</p>
+			<!-- /wp:paragraph -->
+		
+			<!-- wp:group {"className":"wporg-theme-preview__download","layout":{"type":"constrained"}} -->
+			<div class="wp-block-group wporg-theme-preview__download">
+				<!-- wp:spacer {"height":"0"} -->
+				<div style="height:0" aria-hidden="true" class="wp-block-spacer"></div>
+				<!-- /wp:spacer -->
+				
+				<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
+				<div class="wp-block-buttons">
+					<!-- wp:button {"width":100,"metadata":{"bindings":{"url":{"source":"wporg-themes/meta","args":{"key":"download-url"}},"text":{"source":"wporg-themes/meta","args":{"key":"download-text"}}}},"className":"is-style-fill-on-dark"} -->
+					<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-on-dark"><a class="wp-block-button__link wp-element-button">Download</a></div>
+					<!-- /wp:button -->
+				</div>
+				<!-- /wp:buttons -->
+		
+				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|light-grey-1"}}},"spacing":{"margin":{"top":"var:preset|spacing|10"}}},"textColor":"light-grey-1","className":"is-style-short-text","fontSize":"extra-small","metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"zip-name"}}}}} -->
+				<p class="has-text-align-center is-style-short-text has-light-grey-1-color has-text-color has-link-color has-extra-small-font-size" style="margin-top:var(--wp--preset--spacing--10)"></p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
+		
+		<!-- wp:column {"width":"","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"blueberry-4"} -->
+		<div class="wp-block-column has-blueberry-4-background-color has-background" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--30)">
+			<!-- wp:paragraph -->
+			<p>iframed preview</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</main>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-themes-2024/templates/preview.html
+++ b/source/wp-content/themes/wporg-themes-2024/templates/preview.html
@@ -2,8 +2,8 @@
 <main class="wp-block-group entry-content">
 	<!-- wp:columns {"align":"full","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}},"className":"wporg-theme-preview__container"} -->
 	<div class="wp-block-columns alignfull wporg-theme-preview__container">
-		<!-- wp:column {"width":"300px","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-3"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}},"backgroundColor":"charcoal-1","textColor":"white"} -->
-		<div class="wp-block-column has-white-color has-charcoal-1-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20);flex-basis:300px">
+		<!-- wp:column {"width":"300px","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-3"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}},"border":{"right":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"},"top":{},"bottom":{},"left":{}}},"backgroundColor":"charcoal-1","textColor":"white"} -->
+		<div class="wp-block-column has-white-color has-charcoal-1-background-color has-text-color has-background has-link-color" style="border-right-color:var(--wp--preset--color--white-opacity-15);border-right-style:solid;border-right-width:1px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20);flex-basis:300px">
 			<!-- wp:buttons {"className":"wporg-theme-preview__back"} -->
 			<div class="wp-block-buttons wporg-theme-preview__back">
 				<!-- wp:button {"className":"is-style-outline-on-dark is-small","metadata":{"bindings":{"url":{"source":"wporg-themes/meta","args":{"key":"preview-back-url"}},"text":{"source":"wporg-themes/meta","args":{"key":"preview-back-text"}}}}} -->
@@ -48,11 +48,9 @@
 		</div>
 		<!-- /wp:column -->
 		
-		<!-- wp:column {"width":"","style":{"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"backgroundColor":"blueberry-4"} -->
-		<div class="wp-block-column has-blueberry-4-background-color has-background" style="padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--30)">
-			<!-- wp:paragraph -->
-			<p>iframed preview</p>
-			<!-- /wp:paragraph -->
+		<!-- wp:column {"width":""} -->
+		<div class="wp-block-column">
+			<!-- wp:wporg/theme-previewer /-->
 		</div>
 		<!-- /wp:column -->
 	</div>

--- a/source/wp-content/themes/wporg-themes-2024/templates/preview.html
+++ b/source/wp-content/themes/wporg-themes-2024/templates/preview.html
@@ -26,6 +26,8 @@
 			<p>[style variations]</p>
 			<!-- /wp:paragraph -->
 
+			<!-- wp:wporg/theme-patterns {"showAll":true} /-->
+
 			<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"},"spacing":{"padding":{"bottom":"var:preset|spacing|20"}},"border":{"top":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"},"right":{},"bottom":{},"left":{}}},"className":"wporg-theme-preview__download","layout":{"type":"constrained"}} -->
 			<div class="wp-block-group wporg-theme-preview__download" style="border-top-color:var(--wp--preset--color--white-opacity-15);border-top-style:solid;border-top-width:1px;padding-bottom:var(--wp--preset--spacing--20)">
 				<!-- wp:spacer {"height":"0"} -->

--- a/source/wp-content/themes/wporg-themes-2024/templates/preview.html
+++ b/source/wp-content/themes/wporg-themes-2024/templates/preview.html
@@ -2,8 +2,8 @@
 <main class="wp-block-group entry-content">
 	<!-- wp:columns {"align":"full","style":{"spacing":{"blockGap":{"top":"0","left":"0"}}},"className":"wporg-theme-preview__container"} -->
 	<div class="wp-block-columns alignfull wporg-theme-preview__container">
-		<!-- wp:column {"width":"300px","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-3"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}},"border":{"right":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"},"top":{},"bottom":{},"left":{}}},"backgroundColor":"charcoal-1","textColor":"white"} -->
-		<div class="wp-block-column has-white-color has-charcoal-1-background-color has-text-color has-background has-link-color" style="border-right-color:var(--wp--preset--color--white-opacity-15);border-right-style:solid;border-right-width:1px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20);flex-basis:300px">
+		<!-- wp:column {"width":"300px","style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-3"}}},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"0","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}},"border":{"right":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"},"top":{},"bottom":{},"left":{}}},"backgroundColor":"charcoal-1","textColor":"white"} -->
+		<div class="wp-block-column has-white-color has-charcoal-1-background-color has-text-color has-background has-link-color" style="border-right-color:var(--wp--preset--color--white-opacity-15);border-right-style:solid;border-right-width:1px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:0;padding-left:var(--wp--preset--spacing--20);flex-basis:300px">
 			<!-- wp:buttons {"className":"wporg-theme-preview__back"} -->
 			<div class="wp-block-buttons wporg-theme-preview__back">
 				<!-- wp:button {"className":"is-style-outline-on-dark is-small","metadata":{"bindings":{"url":{"source":"wporg-themes/meta","args":{"key":"preview-back-url"}},"text":{"source":"wporg-themes/meta","args":{"key":"preview-back-text"}}}}} -->
@@ -25,9 +25,9 @@
 			<!-- wp:paragraph -->
 			<p>[style variations]</p>
 			<!-- /wp:paragraph -->
-		
-			<!-- wp:group {"className":"wporg-theme-preview__download","layout":{"type":"constrained"}} -->
-			<div class="wp-block-group wporg-theme-preview__download">
+
+			<!-- wp:group {"style":{"position":{"type":"sticky","top":"0px"},"spacing":{"padding":{"bottom":"var:preset|spacing|20"}},"border":{"top":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"},"right":{},"bottom":{},"left":{}}},"className":"wporg-theme-preview__download","layout":{"type":"constrained"}} -->
+			<div class="wp-block-group wporg-theme-preview__download" style="border-top-color:var(--wp--preset--color--white-opacity-15);border-top-style:solid;border-top-width:1px;padding-bottom:var(--wp--preset--spacing--20)">
 				<!-- wp:spacer {"height":"0"} -->
 				<div style="height:0" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->


### PR DESCRIPTION
See #38 — This adds a new path to the site, ex `https://wordpress.org/themes/twentytwentyfour/preview/`, which will show a new `preview.html` template. The preview template sets up 2 columns, on the left is the theme information, and the right has the `iframe`d preview of wp-themes.com.

This matches the current production previewer with the following features:

- [x] The page loads the theme preview, with theme info
- [x] The preview can toggle between three screen sizes
- [x] There is a download button
- [x] There is a back button to return to the theme details page
- [x] It is possible to preview a pattern page `/twentytwentytwo/preview/?pattern_name=twentytwentytwo%2Ffooter-about-title-logo`
- [x] Viewing a style variation shows the theme with that applied `/twentytwentytwo/preview/?style_variation=pink`
- [x] New: Combining the two also works `/twentytwentytwo/preview/?pattern_name=twentytwentytwo%2Ffooter-about-title-logo&style_variation=pink`

Additionally, I've added in the available patterns to the sidebar, clicking a pattern will load that preview. This can create a very long list though, so I can easily remove it if necessary.

In following PRs:

- Adjust the frame on small screens
- The style variations list is not available yet, once the block is built it can be added here
- Maybe remove patterns list

### Screenshots

| | Screenshot |
|---|---|
| Previewer (default) | ![previewer-1](https://github.com/WordPress/wporg-theme-directory/assets/541093/5a8cab55-c62d-4bf9-bf1f-f3e3e56c1e90) |
| Previewer (mobile) | ![previewer-m](https://github.com/WordPress/wporg-theme-directory/assets/541093/33499a80-27f8-41ee-a6bc-773c97b35a8f) |
| Previewer (different style variation) | ![previewer-style](https://github.com/WordPress/wporg-theme-directory/assets/541093/699deba5-62fc-4407-be14-918774cf5a6a) |
