### PR TITLE
New blocks: Theme style variations

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -13,6 +13,7 @@ require_once( __DIR__ . '/src/ratings-stars/index.php' );
 require_once( __DIR__ . '/src/theme-patterns/index.php' );
 require_once( __DIR__ . '/src/theme-previewer/index.php' );
 require_once( __DIR__ . '/src/theme-style-variations/index.php' );
+require_once( __DIR__ . '/src/theme-style-variations-items/index.php' );
 
 /**
  * Actions and filters.

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -12,6 +12,7 @@ require_once( __DIR__ . '/src/ratings-bars/index.php' );
 require_once( __DIR__ . '/src/ratings-stars/index.php' );
 require_once( __DIR__ . '/src/theme-patterns/index.php' );
 require_once( __DIR__ . '/src/theme-previewer/index.php' );
+require_once( __DIR__ . '/src/theme-style-variations/index.php' );
 
 /**
  * Actions and filters.

--- a/source/wp-content/themes/wporg-themes-2024/patterns/single.php
+++ b/source/wp-content/themes/wporg-themes-2024/patterns/single.php
@@ -26,8 +26,6 @@
 <div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--40)">
 	<!-- wp:column {"width":"70%","style":{"spacing":{"blockGap":"0"}}} -->
 	<div class="wp-block-column" style="flex-basis:70%">
-		<!-- wp:post-featured-image {"style":{"border":{"radius":"3px","style":"solid","width":"1px"}},"borderColor":"black-opacity-15"} /-->
-
 		<!-- wp:wporg/theme-style-variations /-->
 	</div>
 	<!-- /wp:column -->

--- a/source/wp-content/themes/wporg-themes-2024/patterns/single.php
+++ b/source/wp-content/themes/wporg-themes-2024/patterns/single.php
@@ -28,9 +28,7 @@
 	<div class="wp-block-column" style="flex-basis:70%">
 		<!-- wp:post-featured-image {"style":{"border":{"radius":"3px","style":"solid","width":"1px"}},"borderColor":"black-opacity-15"} /-->
 
-		<!-- wp:paragraph -->
-		<p>[style filters]</p>
-		<!-- /wp:paragraph -->
+		<!-- wp:wporg/theme-style-variations /-->
 	</div>
 	<!-- /wp:column -->
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/_page.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/_page.scss
@@ -28,14 +28,6 @@
 		padding-inline: var(--wp--preset--spacing--20);
 	}
 
-	.wporg-theme-style-variations__row {
-		display: grid;
-		grid-template-columns: repeat(2, 1fr);
-		gap: var(--wp--preset--spacing--10);
-		margin-block-start: 0;
-		overflow-x: initial;
-	}
-
 	.wporg-theme-patterns__grid {
 		grid-template-columns: repeat(2, 1fr);
 		gap: var(--wp--preset--spacing--10);

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/block.json
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/block.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/theme-style-variations-items",
+	"version": "0.1.0",
+	"title": "Theme style variations (items)",
+	"category": "design",
+	"icon": "",
+	"description": "A list of style variations provided by this theme (with demo screenshots), variations only, grid-style.",
+	"textdomain": "wporg",
+	"attributes": {},
+	"supports": {
+		"html": false
+	},
+	"usesContext": [ "postId", "postType" ],
+	"editorScript": "file:./index.js",
+	"style": "wporg-theme-style-variations-style",
+	"render": "file:./render.php"
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/index.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from '../utils/dynamic-edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/index.php
@@ -36,9 +36,7 @@ function get_style_variation_card( $style ) {
 		'alt' => sprintf( __( 'Style: %s', 'wporg-themes' ), $style->title ),
 		'href' => $preview_link,
 		'width' => 100,
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Name comes from API.
 		'viewportWidth' => 1180,
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Name comes from API.
 		'viewportHeight' => 740,
 		'fullPage' => false,
 	);

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/index.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Block Name: Theme style variations (items)
+ * Description: A list of style variations provided by this theme (with demo screenshots), variations only, grid-style.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Theme_Directory_2024\Theme_Style_Variations_Items;
+
+use WP_HTML_Tag_Processor;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Register the block.
+ */
+function init() {
+	register_block_type( dirname( dirname( __DIR__ ) ) . '/build/theme-style-variations-items' );
+}
+
+/**
+ * Convert a style object into a screenshot preview block.
+ */
+function get_style_variation_card( $style ) {
+	$preview_link = $style->preview_base;
+	if ( str_contains( $style->link, 'style_variation' ) ) {
+		$preview_link = add_query_arg( 'style_variation', $style->title, $style->preview_base );
+	}
+
+	$args = array(
+		'src' => $style->preview_link,
+		// translators: %s pattern name.
+		'alt' => sprintf( __( 'Style: %s', 'wporg-themes' ), $style->title ),
+		'href' => $preview_link,
+		'width' => 100,
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Name comes from API.
+		'viewportWidth' => 1180,
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Name comes from API.
+		'viewportHeight' => 740,
+		'fullPage' => false,
+	);
+	$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', wp_json_encode( $args ) ) );
+
+	$html = new WP_HTML_Tag_Processor( $block_markup );
+	$html->next_tag( 'a' );
+	$html->set_attribute( 'data-wp-on--click', 'wporg/themes/preview::actions.setIframeUrl' );
+
+	return $html->get_updated_html();
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/render.php
@@ -1,0 +1,42 @@
+<?php
+
+use function WordPressdotorg\Theme\Theme_Directory_2024\get_theme_style_variations;
+use function WordPressdotorg\Theme\Theme_Directory_2024\Theme_Style_Variations_Items\get_style_variation_card;
+
+$current_post_id = $block->context['postId'];
+if ( ! $current_post_id ) {
+	return;
+}
+
+$theme_post = get_post( $block->context['postId'] );
+$styles = get_theme_style_variations( $theme_post->post_name );
+$count = count( $styles );
+
+if ( ! $count ) {
+	return '';
+}
+
+$label = sprintf(
+	/* translators: Heading for style variations, %s is the number of styles. */
+	_n( 'Style variations (%s)', 'Style variations (%s)', $count, 'wporg-themes' ),
+	$count
+);
+
+?>
+<div
+	data-wp-interactive="wporg/themes/style-variations"
+	<?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>
+>
+	<div class="wporg-theme-style-variations__heading">
+		<h2><?php echo esc_html( $label ); ?></h2>
+	</div>
+
+	<div class="wporg-theme-style-variations__grid">
+		<?php
+		foreach ( $styles as $i => $style ) {
+			$style->preview_base = untrailingslashit( get_permalink( $theme_post ) ) . '/preview/';
+			echo get_style_variation_card( $style ); // phpcs:ignore
+		}
+		?>
+	</div>
+</div>

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/block.json
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/block.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/theme-style-variations",
+	"version": "0.1.0",
+	"title": "Theme style variations",
+	"category": "design",
+	"icon": "",
+	"description": "A list of style variations provided by this theme (with screenshots).",
+	"textdomain": "wporg",
+	"supports": {
+		"html": false
+	},
+	"usesContext": [ "postId", "postType" ],
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"render": "file:./render.php",
+	"viewScriptModule": "file:./view.js"
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/block.json
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/block.json
@@ -8,6 +8,12 @@
 	"icon": "",
 	"description": "A list of style variations provided by this theme (with screenshots).",
 	"textdomain": "wporg",
+	"attributes": {
+		"displayStyle": {
+			"type": "string",
+			"enum": [ "row", "grid" ]
+		}
+	},
 	"supports": {
 		"html": false
 	},

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from '../utils/dynamic-edit';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
@@ -37,9 +37,7 @@ function get_style_variation_card( $style ) {
 		'alt' => sprintf( __( 'Style: %s', 'wporg-themes' ), $style->title ),
 		'href' => $preview_link,
 		'width' => 100,
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Name comes from API.
 		'viewportWidth' => 1180,
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Name comes from API.
 		'viewportHeight' => 740,
 		'fullPage' => false,
 	);

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Block Name: Theme style variations
+ * Description: A list of style variations provided by this theme (with screenshots).
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Theme_Directory_2024\Theme_Style_Variations;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Register the block.
+ */
+function init() {
+	register_block_type( dirname( dirname( __DIR__ ) ) . '/build/theme-style-variations' );
+}
+
+/**
+ * Convert a style object into a screenshot preview block.
+ */
+function get_style_variation_card( $style ) {
+	$preview_link = $style->preview_base;
+	if ( str_contains( $style->link, 'style_variation' ) ) {
+		$preview_link = add_query_arg( 'style_variation', $style->title, $style->preview_base );
+	}
+
+	$args = array(
+		'src' => $style->preview_link,
+		// translators: %s pattern name.
+		'alt' => sprintf( __( 'Style: %s', 'wporg-themes' ), $style->title ),
+		'href' => $preview_link,
+		'width' => 100,
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Name comes from API.
+		'viewportWidth' => 1180,
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Name comes from API.
+		'viewportHeight' => 740,
+		'fullPage' => false,
+	);
+	$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', wp_json_encode( $args ) ) );
+
+	return $block_markup;
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
@@ -8,6 +8,9 @@
 
 namespace WordPressdotorg\Theme\Theme_Directory_2024\Theme_Style_Variations;
 
+use WP_HTML_Tag_Processor;
+use function WordPressdotorg\Theme\Theme_Directory_2024\get_theme_style_variations;
+
 defined( 'WPINC' ) || die();
 
 add_action( 'init', __NAMESPACE__ . '\init' );
@@ -42,5 +45,36 @@ function get_style_variation_card( $style ) {
 	);
 	$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', wp_json_encode( $args ) ) );
 
-	return $block_markup;
+	$html = new WP_HTML_Tag_Processor( $block_markup );
+	$html->next_tag( 'a' );
+	$html->set_attribute( 'data-wp-on--click', 'wporg/themes/style-variations::actions.onStyleClick' );
+	$html->set_attribute( 'data-style', strtolower( $style->title ) );
+
+	return $html->get_updated_html();
+}
+
+/**
+ * Get the full-sized images for each style variation, hide everything but the currently-selected item.
+ */
+function get_theme_preview_images( $theme_post ) {
+	$styles = get_theme_style_variations( $theme_post->post_name );
+	$output = '';
+
+	foreach ( $styles as $style ) {
+		if ( ! str_contains( $style->link, 'style_variation' ) ) {
+			$block_markup = do_blocks( '<!-- wp:post-featured-image {"style":{"border":{"radius":"3px","style":"solid","width":"1px"}},"borderColor":"black-opacity-15"} /-->' );
+		} else {
+			$args = array(
+				'src' => $style->link,
+				'fullPage' => false,
+			);
+			$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', wp_json_encode( $args ) ) );
+		}
+
+		$output .= '<div data-wp-bind--hidden="state.isHidden" data-wp-context=\'{"style":"' . strtolower( $style->title ) . '"}\'>';
+		$output .= $block_markup;
+		$output .= '</div>';
+	}
+
+	return $output;
 }

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
@@ -1,14 +1,12 @@
 <?php
 
 use function WordPressdotorg\Theme\Theme_Directory_2024\get_theme_style_variations;
-use function WordPressdotorg\Theme\Theme_Directory_2024\Theme_Style_Variations\get_style_variation_card;
+use function WordPressdotorg\Theme\Theme_Directory_2024\Theme_Style_Variations\{get_style_variation_card, get_theme_preview_images};
 
 $current_post_id = $block->context['postId'];
 if ( ! $current_post_id ) {
 	return;
 }
-
-$display_style = $attributes['displayStyle'] ?? 'row';
 
 $theme_post = get_post( $block->context['postId'] );
 $styles = get_theme_style_variations( $theme_post->post_name );
@@ -27,6 +25,7 @@ $label = sprintf(
 // Initial state to pass to Interactivity API.
 $init_state = [
 	'isRTL' => is_rtl(),
+	'selected' => 'default',
 ];
 $encoded_state = wp_json_encode( $init_state );
 
@@ -38,10 +37,13 @@ $encoded_state = wp_json_encode( $init_state );
 	data-wp-init="actions.init"
 	data-wp-on-window--resize="actions.init"
 >
-	<div class="wporg-theme-style-variations__controls">
+	<div class="wporg-theme-style-variations__screenshot">
+		<?php echo get_theme_preview_images( $theme_post ); // phpcs:ignore ?>
+	</div>
+
+	<div class="wporg-theme-style-variations__heading">
 		<h2><?php echo esc_html( $label ); ?></h2>
 
-		<?php if ( 'row' === $display_style ) : ?>
 		<div
 			class="wporg-theme-style-variations__buttons wp-block-buttons"
 			data-wp-bind--hidden="!state.hasOverscroll"
@@ -69,11 +71,10 @@ $encoded_state = wp_json_encode( $init_state );
 				</button>
 			</div>
 		</div>
-		<?php endif; ?>
 	</div>
 
 	<div
-		class="wporg-theme-style-variations__<?php echo esc_attr( $display_style ); ?>"
+		class="wporg-theme-style-variations__row"
 		data-wp-on--scroll="actions.handleScroll"
 	>
 		<?php

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
@@ -10,14 +10,67 @@ if ( ! $current_post_id ) {
 
 $theme_post = get_post( $block->context['postId'] );
 $styles = get_theme_style_variations( $theme_post->post_name );
+$count = count( $styles );
 
-if ( ! count( $styles ) ) {
+if ( ! $count ) {
 	return '';
 }
 
+$label = sprintf(
+	/* translators: Heading for style variations, %s is the number of styles. */
+	_n( 'Style variations (%s)', 'Style variations (%s)', $count, 'wporg-themes' ),
+	$count
+);
+
+// Initial state to pass to Interactivity API.
+$init_state = [
+	'isRTL' => is_rtl(),
+];
+$encoded_state = wp_json_encode( $init_state );
+
 ?>
-<div <?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>>
-	<div class="wporg-theme-style-variations__row">
+<div
+	<?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>
+	data-wp-interactive="wporg/themes/style-variations"
+	data-wp-context="<?php echo esc_attr( $encoded_state ); ?>"
+	data-wp-init="actions.init"
+	data-wp-on-window--resize="actions.init"
+>
+	<div class="wporg-theme-style-variations__controls">
+		<h2><?php echo esc_html( $label ); ?></h2>
+		<div
+			class="wporg-theme-style-variations__buttons wp-block-buttons"
+			data-wp-bind--hidden="!state.hasOverscroll"
+		>
+			<div class="wp-block-button is-style-toggle is-small">
+				<button
+					tabindex="-1"
+					class="wp-block-button__link wp-element-button"
+					aria-label="Prev"
+					data-wp-on--click="actions.handlePrevious"
+					data-wp-bind--disabled="!state.canPrevious"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M20 11.2H6.8l3.7-3.7-1-1L3.9 12l5.6 5.5 1-1-3.7-3.7H20z"></path></svg>
+				</button>
+			</div>
+			<div class="wp-block-button is-style-toggle is-small">
+				<button
+					tabindex="-1"
+					class="wp-block-button__link wp-element-button"
+					aria-label="Next"
+					data-wp-on--click="actions.handleNext"
+					data-wp-bind--disabled="!state.canNext"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="m14.5 6.5-1 1 3.7 3.7H4v1.6h13.2l-3.7 3.7 1 1 5.6-5.5z"></path></svg>
+				</button>
+			</div>
+		</div>
+	</div>
+
+	<div
+		class="wporg-theme-style-variations__row"
+		data-wp-on--scroll="actions.handleScroll"
+	>
 		<?php
 		foreach ( $styles as $i => $style ) {
 			$style->preview_base = untrailingslashit( get_permalink( $theme_post ) ) . '/preview/';

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
@@ -8,6 +8,8 @@ if ( ! $current_post_id ) {
 	return;
 }
 
+$display_style = $attributes['displayStyle'] ?? 'row';
+
 $theme_post = get_post( $block->context['postId'] );
 $styles = get_theme_style_variations( $theme_post->post_name );
 $count = count( $styles );
@@ -38,6 +40,8 @@ $encoded_state = wp_json_encode( $init_state );
 >
 	<div class="wporg-theme-style-variations__controls">
 		<h2><?php echo esc_html( $label ); ?></h2>
+
+		<?php if ( 'row' === $display_style ) : ?>
 		<div
 			class="wporg-theme-style-variations__buttons wp-block-buttons"
 			data-wp-bind--hidden="!state.hasOverscroll"
@@ -65,10 +69,11 @@ $encoded_state = wp_json_encode( $init_state );
 				</button>
 			</div>
 		</div>
+		<?php endif; ?>
 	</div>
 
 	<div
-		class="wporg-theme-style-variations__row"
+		class="wporg-theme-style-variations__<?php echo esc_attr( $display_style ); ?>"
 		data-wp-on--scroll="actions.handleScroll"
 	>
 		<?php

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
@@ -13,7 +13,9 @@ $styles = get_theme_style_variations( $theme_post->post_name );
 $count = count( $styles );
 
 if ( ! $count ) {
-	return '';
+	// phpcs:ignore
+	echo do_blocks( '<!-- wp:post-featured-image {"style":{"border":{"radius":"3px","style":"solid","width":"1px"}},"borderColor":"black-opacity-15"} /-->' );
+	return;
 }
 
 $label = sprintf(

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
@@ -1,0 +1,28 @@
+<?php
+
+use function WordPressdotorg\Theme\Theme_Directory_2024\get_theme_style_variations;
+use function WordPressdotorg\Theme\Theme_Directory_2024\Theme_Style_Variations\get_style_variation_card;
+
+$current_post_id = $block->context['postId'];
+if ( ! $current_post_id ) {
+	return;
+}
+
+$theme_post = get_post( $block->context['postId'] );
+$styles = get_theme_style_variations( $theme_post->post_name );
+
+if ( ! count( $styles ) ) {
+	return '';
+}
+
+?>
+<div <?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>>
+	<div class="wporg-theme-style-variations__row">
+		<?php
+		foreach ( $styles as $i => $style ) {
+			$style->preview_base = untrailingslashit( get_permalink( $theme_post ) ) . '/preview/';
+			echo get_style_variation_card( $style ); // phpcs:ignore
+		}
+		?>
+	</div>
+</div>

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
@@ -31,6 +31,23 @@
 	}
 }
 
+.wporg-theme-style-variations__row,
+.wporg-theme-style-variations__grid {
+	&:focus {
+		outline: none;
+		border-radius: 2px;
+		box-shadow: 0 0 0 1.5px var(--wp--custom--link--color--text);
+	}
+
+	.wp-block-wporg-screenshot-preview {
+		min-width: 100px;
+
+		.wporg-screenshot-preview__container {
+			aspect-ratio: 200/125;
+		}
+	}
+}
+
 .wporg-theme-style-variations__row {
 	display: flex;
 	gap: var(--wp--preset--spacing--10);
@@ -40,18 +57,15 @@
 	scroll-snap-type: inline mandatory;
 	scrollbar-width: none;
 
-	&:focus {
-		outline: none;
-		border-radius: 2px;
-		box-shadow: 0 0 0 1.5px var(--wp--custom--link--color--text);
-	}
-
 	.wp-block-wporg-screenshot-preview {
 		flex-basis: 100px;
-		min-width: 100px;
-
-		.wporg-screenshot-preview__container {
-			aspect-ratio: 200/125;
-		}
 	}
+}
+
+.wporg-theme-style-variations__grid {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: var(--wp--preset--spacing--10);
+	margin-block-start: 0;
+	overflow-x: initial;
 }

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
@@ -1,0 +1,18 @@
+.wporg-theme-style-variations__row {
+	display: flex;
+	gap: var(--wp--preset--spacing--10);
+	margin-block-start: var(--wp--preset--spacing--10);
+	list-style: none;
+	overflow-x: scroll;
+	overscroll-behavior: contain;
+	scroll-snap-type: inline mandatory;
+	scrollbar-width: none;
+
+	.wp-block-wporg-screenshot-preview {
+		flex-basis: 100px;
+
+		.wporg-screenshot-preview__container {
+			aspect-ratio: 200/125;
+		}
+	}
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
@@ -1,4 +1,10 @@
-.wporg-theme-style-variations__controls {
+.wporg-theme-style-variations__screenshot {
+	figure {
+		margin-bottom: 0;
+	}
+}
+
+.wporg-theme-style-variations__heading {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
@@ -1,15 +1,54 @@
+.wporg-theme-style-variations__controls {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-block-start: var(--wp--preset--spacing--10);
+
+	h2 {
+		margin: 0 !important;
+		font-family: var(--wp--preset--font-family--inter);
+		font-size: var(--wp--preset--font-size--normal);
+		line-height: var(--wp--custom--body--typography--line-height);
+	}
+
+	.wporg-theme-style-variations__buttons {
+		svg {
+			vertical-align: middle;
+			fill: var(--wp--preset--color--charcoal-4) !important;
+
+			html[dir="rtl"] & {
+				transform: rotate(180deg);
+			}
+		}
+
+		[disabled] {
+			pointer-events: none;
+
+			svg {
+				fill: var(--wp--preset--color--charcoal-5) !important;
+			}
+		}
+	}
+}
+
 .wporg-theme-style-variations__row {
 	display: flex;
 	gap: var(--wp--preset--spacing--10);
 	margin-block-start: var(--wp--preset--spacing--10);
-	list-style: none;
 	overflow-x: scroll;
 	overscroll-behavior: contain;
 	scroll-snap-type: inline mandatory;
 	scrollbar-width: none;
 
+	&:focus {
+		outline: none;
+		border-radius: 2px;
+		box-shadow: 0 0 0 1.5px var(--wp--custom--link--color--text);
+	}
+
 	.wp-block-wporg-screenshot-preview {
 		flex-basis: 100px;
+		min-width: 100px;
 
 		.wporg-screenshot-preview__container {
 			aspect-ratio: 200/125;

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/view.js
@@ -1,0 +1,78 @@
+/**
+ * WordPress dependencies
+ */
+import { getContext, getElement, store } from '@wordpress/interactivity';
+
+const OFFSET_WIDTH = 220;
+
+/**
+ * Get the "row" element starting with any block child element.
+ *
+ * @param {Element} ref
+ *
+ * @return {Element}
+ */
+function getRowElement( ref ) {
+	const container = ref.closest( '.wp-block-wporg-theme-style-variations' );
+	const element = container.querySelector( '.wporg-theme-style-variations__row' );
+	return element;
+}
+
+// Note about RTL: Browsers scroll "left" into the negative when on RTL, so the
+// logic for when we "canNext"/"canPrevious" are swapped, as are the offsets
+// triggered when clicking the arrow buttons.
+
+const { state } = store( 'wporg/themes/style-variations', {
+	state: {
+		get canPrevious() {
+			const { isRTL } = getContext();
+			if ( isRTL ) {
+				return state.position < 0;
+			}
+			return state.position > 0;
+		},
+		get canNext() {
+			const { isRTL } = getContext();
+			if ( isRTL ) {
+				return state.position >= state.overflow * -1;
+			}
+			return state.position < state.overflow;
+		},
+		get hasOverscroll() {
+			return state.canNext || state.canPrevious;
+		},
+		position: 0,
+		overflow: 0,
+	},
+	actions: {
+		init() {
+			const element = getRowElement( getElement().ref );
+			state.position = element.scrollLeft;
+			// How much extra scroll overflow do we have?
+			state.overflow =
+				element.children.length * 100 + ( element.children.length - 1 ) * 10 - element.clientWidth;
+		},
+		handleScroll() {
+			const element = getRowElement( getElement().ref );
+			state.position = element.scrollLeft;
+		},
+		handlePrevious() {
+			const { isRTL } = getContext();
+			const element = getRowElement( getElement().ref );
+			const position = isRTL ? element.scrollLeft + OFFSET_WIDTH : element.scrollLeft - OFFSET_WIDTH;
+			element.scrollTo( {
+				left: position,
+				behavior: 'smooth',
+			} );
+		},
+		handleNext() {
+			const { isRTL } = getContext();
+			const element = getRowElement( getElement().ref );
+			const position = isRTL ? element.scrollLeft - OFFSET_WIDTH : element.scrollLeft + OFFSET_WIDTH;
+			element.scrollTo( {
+				left: position,
+				behavior: 'smooth',
+			} );
+		},
+	},
+} );

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/view.js
@@ -41,8 +41,14 @@ const { state } = store( 'wporg/themes/style-variations', {
 		get hasOverscroll() {
 			return state.canNext || state.canPrevious;
 		},
+		get isHidden() {
+			// Each screenshot resets the context with its style.
+			const context = getContext();
+			return context.style !== state.selected;
+		},
 		position: 0,
 		overflow: 0,
+		selected: 'default',
 	},
 	actions: {
 		init() {
@@ -73,6 +79,11 @@ const { state } = store( 'wporg/themes/style-variations', {
 				left: position,
 				behavior: 'smooth',
 			} );
+		},
+		onStyleClick( event ) {
+			event.preventDefault();
+			const { ref } = getElement();
+			state.selected = ref?.dataset.style;
 		},
 	},
 } );

--- a/source/wp-content/themes/wporg-themes-2024/templates/preview.html
+++ b/source/wp-content/themes/wporg-themes-2024/templates/preview.html
@@ -19,7 +19,7 @@
 	
 		<!-- wp:post-excerpt {"fontSize":"small"} /-->
 	
-		<!-- wp:wporg/theme-style-variations /-->
+		<!-- wp:wporg/theme-style-variations {"displayStyle":"grid"} /-->
 
 		<!-- wp:wporg/theme-patterns {"showAll":true} /-->
 

--- a/source/wp-content/themes/wporg-themes-2024/templates/preview.html
+++ b/source/wp-content/themes/wporg-themes-2024/templates/preview.html
@@ -19,9 +19,7 @@
 	
 		<!-- wp:post-excerpt {"fontSize":"small"} /-->
 	
-		<!-- wp:paragraph -->
-		<p>[style variations]</p>
-		<!-- /wp:paragraph -->
+		<!-- wp:wporg/theme-style-variations /-->
 
 		<!-- wp:wporg/theme-patterns {"showAll":true} /-->
 

--- a/source/wp-content/themes/wporg-themes-2024/templates/preview.html
+++ b/source/wp-content/themes/wporg-themes-2024/templates/preview.html
@@ -19,7 +19,7 @@
 	
 		<!-- wp:post-excerpt {"fontSize":"small"} /-->
 	
-		<!-- wp:wporg/theme-style-variations {"displayStyle":"grid"} /-->
+		<!-- wp:wporg/theme-style-variations-items /-->
 
 		<!-- wp:wporg/theme-patterns {"showAll":true} /-->
 


### PR DESCRIPTION
This PR adds two new blocks, one for the style variations and larger preview screenshot, and one for inside the previewer itself. The variations on the theme detail page appear in a row, with arrows to scroll the container. When clicked, those update the larger screenshot. On the preview page, the style variations appear all in a grid, and clicking those update the style used in the live preview.

Fixes #31 

Theme detail page:

<img width="1316" alt="Screenshot 2024-04-29 at 5 08 00 PM" src="https://github.com/WordPress/wporg-theme-directory/assets/541093/2d7c6c80-729f-4374-a5b2-c9928467239c">

Theme previewer sidebar:

<img width="287" alt="Screenshot 2024-04-29 at 5 08 16 PM" src="https://github.com/WordPress/wporg-theme-directory/assets/541093/9be64069-690c-4c56-a97a-4534b9031cd1">


