### PR TITLE
Update menu order to match plugins.

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
@@ -161,12 +161,12 @@ function add_site_navigation_menus( $menus ) {
 	$menu = array();
 
 	$menu[] = array(
-		'label' => __( 'Submit a theme', 'wporg-themes' ),
-		'url' => '/getting-started/',
-	);
-	$menu[] = array(
 		'label' => __( 'My favorites', 'wporg-themes' ),
 		'url' => '/browse/favorites/',
+	);
+	$menu[] = array(
+		'label' => __( 'Submit a theme', 'wporg-themes' ),
+		'url' => '/getting-started/',
 	);
 	$menu[] = array(
 		'label' => __( 'Commercial theme companies', 'wporg-themes' ),


### PR DESCRIPTION
I'm not sure which directory is correct, but this makes it match the plugin directory order.

If this isn't the one we want to change, we can close this.
