### PR TITLE
Add locale suggestion endpoint & block

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -5,6 +5,7 @@ namespace WordPressdotorg\Theme\Theme_Directory_2024;
 require_once( __DIR__ . '/inc/block-bindings.php' );
 require_once( __DIR__ . '/inc/block-config.php' );
 require_once( __DIR__ . '/inc/rest-api.php' );
+require_once( __DIR__ . '/inc/rest-api-locale.php' );
 
 // Block files
 require_once( __DIR__ . '/src/business-model-notice/index.php' );

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
@@ -5,6 +5,7 @@
 
 namespace WordPressdotorg\Theme\Theme_Directory_2024\Block_Config;
 
+use WP_HTML_Tag_Processor;
 use function WordPressdotorg\Theme\Theme_Directory_2024\{ get_query_tags, wporg_themes_get_feature_list };
 
 add_filter( 'wporg_query_total_label', __NAMESPACE__ . '\update_query_total_label', 10, 2 );
@@ -14,6 +15,7 @@ add_filter( 'wporg_query_filter_options_subjects', __NAMESPACE__ . '\get_subject
 add_action( 'wporg_query_filter_in_form', __NAMESPACE__ . '\inject_other_filters', 10, 2 );
 add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
 add_filter( 'render_block_wporg/link-wrapper', __NAMESPACE__ . '\inject_permalink_link_wrapper' );
+add_filter( 'render_block_wporg/language-suggest', __NAMESPACE__ . '\inject_language_suggest_endpoint' );
 
 /**
  * Update the query total label to reflect "patterns" found.
@@ -232,4 +234,22 @@ function add_site_navigation_menus( $menus ) {
  */
 function inject_permalink_link_wrapper( $block_content ) {
 	return str_replace( 'href=""', 'href="' . get_permalink() . '"', $block_content );
+}
+
+/**
+ * Update the endpoint used in `wporg/language-suggest` for the current theme.
+ *
+ * @param string $block_content The block content.
+ *
+ * @return array The updated block.
+ */
+function inject_language_suggest_endpoint( $block_content ) {
+	$html = new WP_HTML_Tag_Processor( $block_content );
+	$html->next_tag();
+	$endpoint_url = rest_url( '/wporg-themes/v1/locale-banner/' );
+	if ( is_single() ) {
+		$endpoint_url = trailingslashit( $endpoint_url . get_queried_object()->post_name );
+	}
+	$html->set_attribute( 'data-endpoint', $endpoint_url );
+	return $html->get_updated_html();
 }

--- a/source/wp-content/themes/wporg-themes-2024/inc/rest-api-locale.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/rest-api-locale.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Set up some helper API endpoints.
+ */
+
+namespace WordPressdotorg\Theme\Theme_Directory_2024\REST_API\Locale;
+
+/**
+ * Get all locales with subdomain mapping.
+ */
+function get_all_locales_with_subdomain() {
+	global $wpdb;
+	return $wpdb->get_results(
+		"SELECT locale, subdomain FROM wporg_locales WHERE locale NOT LIKE '%\_%\_%'",
+		OBJECT_K
+	);
+}
+
+/**
+ * Validate that all the locale subdomains have valid WordPress locale values (hint: They don't).
+ */
+function get_all_valid_locales() {
+	$all_locales = get_all_locales_with_subdomain();
+	// Retrieve all the WordPress locales.
+	$all_locales = wp_list_pluck( $all_locales, 'locale' );
+
+	return array_filter(
+		$all_locales,
+		function( $locale ) {
+			return \GP_Locales::by_field( 'wp_locale', $locale );
+		}
+	);
+}
+
+/**
+ * Get locales matching the HTTP accept language header.
+ *
+ * @return array List of locales.
+ */
+function get_locale_from_header() {
+	$res = array();
+
+	$available_locales = get_all_valid_locales();
+	if ( ! $available_locales ) {
+		return $res;
+	}
+
+	if ( ! isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) {
+		return $res;
+	}
+
+	$http_locales = get_http_locales( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ); // phpcs:ignore
+
+	if ( is_array( $http_locales ) ) {
+		foreach ( $http_locales as $http_locale ) {
+			$lang   = $http_locale;
+			$region = $http_locale;
+			if ( str_contains( $http_locale, '-' ) ) {
+				list( $lang, $region ) = explode( '-', $http_locale );
+			}
+
+			/*
+			 * Discard English -- it's the default for all browsers,
+			 * ergo not very reliable information
+			 */
+			if ( 'en' === $lang ) {
+				continue;
+			}
+
+			// Region should be uppercase.
+			$region = strtoupper( $region );
+
+			$mapped = map_locale( $lang, $region, $available_locales );
+			if ( $mapped ) {
+				$res[] = $mapped;
+			}
+		}
+
+		$res = array_unique( $res );
+	}
+
+	return $res;
+}
+
+/**
+ * Given a HTTP Accept-Language header $header
+ * returns all the locales in it.
+ *
+ * @param string $header HTTP acccept header.
+ * @return array Matched locales.
+ */
+function get_http_locales( $header ) {
+	$locale_part_re = '[a-z]{2,}';
+	$locale_re      = "($locale_part_re(\-$locale_part_re)?)";
+
+	if ( preg_match_all( "/$locale_re/i", $header, $matches ) ) {
+		return $matches[0];
+	} else {
+		return [];
+	}
+}
+
+/**
+ * Tries to map a lang/region pair to one of our locales.
+ *
+ * @param string $lang              Lang part of the HTTP accept header.
+ * @param string $region            Region part of the HTTP accept header.
+ * @param array  $available_locales List of available locales.
+ * @return string|false Our locale matching $lang and $region, false otherwise.
+ */
+function map_locale( $lang, $region, $available_locales ) {
+	$uregion  = strtoupper( $region );
+	$ulang    = strtoupper( $lang );
+	$variants = array(
+		"$lang-$region",
+		"{$lang}_$region",
+		"$lang-$uregion",
+		"{$lang}_$uregion",
+		"{$lang}_$ulang",
+		$lang,
+	);
+
+	foreach ( $variants as $variant ) {
+		if ( in_array( $variant, $available_locales ) ) {
+			return $variant;
+		}
+	}
+
+	foreach ( $available_locales as $locale ) {
+		list( $locale_lang, ) = preg_split( '/[_-]/', $locale );
+		if ( $lang === $locale_lang ) {
+			return $locale;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Get the active language packs for a theme.
+ */
+function get_transalated_locales( $theme_slug ) {
+	global $wpdb;
+
+	$language_packs = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT *
+			FROM language_packs
+			WHERE
+				type = 'theme' AND
+				domain = %s AND
+				active = 1
+			GROUP BY language",
+			$theme_slug
+		)
+	);
+
+	// Retrieve all the WordPress locales in which the theme is translated.
+	$translated_locales = wp_list_pluck( $language_packs, 'language' );
+
+	require_once GLOTPRESS_LOCALES_PATH;
+
+	// Validate the list of locales can be found by `wp_locale`.
+	return array_filter(
+		$translated_locales,
+		function( $locale ) {
+			return \GP_Locales::by_field( 'wp_locale', $locale );
+		}
+	);
+}

--- a/source/wp-content/themes/wporg-themes-2024/inc/rest-api.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/rest-api.php
@@ -5,6 +5,8 @@
 
 namespace WordPressdotorg\Theme\Theme_Directory_2024\REST_API;
 
+use function WordPressdotorg\Theme\Theme_Directory_2024\REST_API\Locale\{ get_all_locales_with_subdomain, get_all_valid_locales, get_locale_from_header, get_transalated_locales };
+
 add_action( 'rest_api_init', __NAMESPACE__ . '\init' );
 
 /**
@@ -38,6 +40,29 @@ function init() {
 			'callback' => __NAMESPACE__ . '\delete_favorite',
 			'args' => $favorite_args,
 			'permission_callback' => 'is_user_logged_in',
+		)
+	);
+	register_rest_route(
+		$namespace,
+		'/locale-banner/',
+		array(
+			'methods' => \WP_REST_Server::READABLE,
+			'callback' => __NAMESPACE__ . '\get_locale_banner',
+			'permission_callback' => '__return_true',
+		)
+	);
+	register_rest_route(
+		$namespace,
+		'/locale-banner/(?P<theme_slug>[^/]+)/',
+		array(
+			'methods' => \WP_REST_Server::READABLE,
+			'callback' => __NAMESPACE__ . '\get_locale_banner_for_theme',
+			'args' => array(
+				'theme_slug' => array(
+					'validate_callback' => __NAMESPACE__ . '\check_theme_slug',
+				),
+			),
+			'permission_callback' => '__return_true',
 		)
 	);
 }
@@ -74,4 +99,164 @@ function delete_favorite( $request ) {
 	}
 
 	return new \WP_REST_Response( [ 'success' => true ] );
+}
+
+/**
+ * Get banner for general theme directory
+ */
+function get_locale_banner( $request ) {
+	if ( ! defined( 'GLOTPRESS_LOCALES_PATH' ) ) {
+		return;
+	}
+
+	$locale_subdomain_assoc = get_all_locales_with_subdomain();
+
+	require_once GLOTPRESS_LOCALES_PATH;
+
+	$current_locale = get_locale();
+	$current_gp_locale = \GP_Locales::by_field( 'wp_locale', $current_locale );
+	$translated_locales = get_transalated_locales( $theme_slug );
+
+	// Build a list of WordPress locales which we'll suggest to the user.
+	$suggest_locales = array_values( array_intersect( get_locale_from_header(), get_all_valid_locales() ) );
+
+	$suggestion_links = [];
+	foreach ( $suggest_locales as $locale ) {
+		$language = \GP_Locales::by_field( 'wp_locale', $locale )->native_name;
+		$suggestion_links[ $locale ] = sprintf(
+			'<a href="https://%s.wordpress.org%s">%s</a>',
+			$locale_subdomain_assoc[ $locale ]->subdomain,
+			esc_url( get_site()->path ),
+			$language
+		);
+	}
+
+	$suggest_string = '';
+
+	unset( $suggestion_links[ $current_locale ] );
+
+	if ( ! empty( $suggestion_links ) ) {
+		$output_locale = key( $suggestion_links );
+		switch_to_locale( $output_locale );
+		$suggest_string = sprintf(
+			// translators: %s: List of links to theme in other locales.
+			__( 'The theme directory is also available in %s.', 'wporg-themes' ),
+			wp_sprintf_l( '%l', $suggestion_links )
+		);
+	}
+
+	// The result should be a raw text response.
+	add_filter( 'rest_pre_echo_response', __NAMESPACE__ . '\send_plain_text' );
+	return new \WP_REST_Response( $suggest_string );
+}
+
+/**
+ * Get banner for single themes.
+ */
+function get_locale_banner_for_theme( $request ) {
+	// This has already been validated by `validate_callback`.
+	$theme_slug = $request['theme_slug'];
+
+	if ( ! defined( 'GLOTPRESS_LOCALES_PATH' ) ) {
+		return;
+	}
+
+	$locale_subdomain_assoc = get_all_locales_with_subdomain();
+
+	require_once GLOTPRESS_LOCALES_PATH;
+
+	$current_locale = get_locale();
+	$current_gp_locale = \GP_Locales::by_field( 'wp_locale', $current_locale );
+	$translated_locales = get_transalated_locales( $theme_slug );
+
+	// Build a list of WordPress locales which we'll suggest to the user.
+	$suggest_locales = array_values( array_intersect( get_locale_from_header(), $translated_locales ) );
+
+	$suggestion_links = [];
+	foreach ( $suggest_locales as $locale ) {
+		$language = \GP_Locales::by_field( 'wp_locale', $locale )->native_name;
+		$suggestion_links[ $locale ] = sprintf(
+			'<a href="https://%s.wordpress.org%s">%s</a>',
+			$locale_subdomain_assoc[ $locale ]->subdomain,
+			esc_url( get_site()->path . $theme_slug . '/' ),
+			$language
+		);
+	}
+
+	$suggest_string = '';
+
+	unset( $suggestion_links[ $current_locale ] );
+
+	// If we're on a rosetta site, and the theme is not translated, the message should ask for help.
+	if ( 'en_US' !== $current_locale && $current_gp_locale && ! in_array( $current_locale, $translated_locales ) ) {
+		$output_locale = $current_locale;
+		switch_to_locale( $output_locale );
+		$suggest_string = sprintf(
+			// translators: %s: Locale name.
+			__( 'This theme is not translated into %s yet.', 'wporg-themes' ),
+			$current_gp_locale->native_name
+		);
+
+		// Append some other suggestions if they exist.
+		if ( ! empty( $suggestion_links ) ) {
+			$suggest_string .= ' ' . sprintf(
+				// translators: %s: List of links to theme in other locales.
+				__( 'This theme is also available in %s.', 'wporg-themes' ),
+				wp_sprintf_l( '%l', $suggestion_links )
+			);
+		}
+
+		// Lastly, add the call for help.
+		$suggest_string .= ' ' . sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( 'https://translate.wordpress.org/projects/wp-themes/' . $theme_slug ),
+			__( 'Help improve the translation!', 'wporg-themes' )
+		);
+
+	} else if ( ! empty( $suggestion_links ) ) {
+		$output_locale = key( $suggestion_links );
+		switch_to_locale( $output_locale );
+		$suggest_string = sprintf(
+			// translators: %s: List of links to theme in other locales.
+			__( 'This theme is also available in %s.', 'wporg-themes' ),
+			wp_sprintf_l( '%l', $suggestion_links )
+		);
+		$suggest_string .= ' ' . sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( 'https://translate.wordpress.org/projects/wp-themes/' . $theme_slug ),
+			__( 'Help improve the translation!', 'wporg-themes' )
+		);
+
+	} else if ( ! empty( $locales_from_header ) ) {
+		$output_locale = reset( $locales_from_header );
+		switch_to_locale( $output_locale );
+
+		$suggest_string = sprintf(
+			// translators: %s: Locale name.
+			__( 'This theme is not translated into %s yet.', 'wporg-themes' ),
+			\GP_Locales::by_field( 'wp_locale', $output_locale )->native_name
+		);
+		$suggest_string .= ' ' . sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( 'https://translate.wordpress.org/projects/wp-themes/' . $theme_slug ),
+			__( 'Help translate it!', 'wporg-themes' )
+		);
+	}
+
+	// The result should be a raw text response.
+	add_filter( 'rest_pre_echo_response', __NAMESPACE__ . '\send_plain_text' );
+	return new \WP_REST_Response( $suggest_string );
+}
+
+/**
+ * Send the response as plain text so it can be used as-is.
+ */
+function send_plain_text( $result ) {
+	// header( 'Content-Type: text/html' );
+	header( 'Content-Type: text/text' );
+	if ( $result ) {
+		echo '<div>' . $result . '</div>'; // phpcs:ignore
+	}
+
+	return null;
 }

--- a/source/wp-content/themes/wporg-themes-2024/inc/rest-api.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/rest-api.php
@@ -201,7 +201,7 @@ function get_locale_banner_for_theme( $request ) {
 		if ( ! empty( $suggestion_links ) ) {
 			$suggest_string .= ' ' . sprintf(
 				// translators: %s: List of links to theme in other locales.
-				__( 'This theme is also available in %s.', 'wporg-themes' ),
+				__( 'This theme is available in %s.', 'wporg-themes' ),
 				wp_sprintf_l( '%l', $suggestion_links )
 			);
 		}

--- a/source/wp-content/themes/wporg-themes-2024/patterns/header-front-page.php
+++ b/source/wp-content/themes/wporg-themes-2024/patterns/header-front-page.php
@@ -16,8 +16,8 @@
 
 <!-- /wp:wporg/local-navigation-bar -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"},"margin":{"bottom":"var:preset|spacing|40"}}},"backgroundColor":"charcoal-2","className":"has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="margin-bottom:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"charcoal-2","className":"has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"bottom"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
@@ -35,3 +35,11 @@
 
 </div>
 <!-- /wp:group -->
+
+<!-- wp:wporg/language-suggest {"align":"full"} -->
+<div class="wp-block-wporg-language-suggest alignfull"></div>
+<!-- /wp:wporg/language-suggest -->
+
+<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
+<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->

--- a/source/wp-content/themes/wporg-themes-2024/patterns/header.php
+++ b/source/wp-content/themes/wporg-themes-2024/patterns/header.php
@@ -16,6 +16,10 @@
 
 <!-- /wp:wporg/local-navigation-bar -->
 
+<!-- wp:wporg/language-suggest {"align":"full"} -->
+<div class="wp-block-wporg-language-suggest alignfull"></div>
+<!-- /wp:wporg/language-suggest -->
+
 <!-- wp:spacer {"height":"var:preset|spacing|40"} -->
 <div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->


### PR DESCRIPTION
Fixes #27 — This adds two API endpoints, a general `locale-banner` and a version that accepts a theme slug (e.g., `locale-banner/twentynineteen`). I've mostly mirrored the plugins endpoint, though I broke the one function into a few steps.

On the homepage, the API will suggest other locales if the user has language hints in the request header. The API should never direct a person to the site they're currently on. On single themes, the API should suggest other rosetta sites only if the theme is translated into those languages.

I'm not sure if it would've been better to abstract out the plugin directory API code and make it reusable across both (I didn't want to get that in the weeds about it), but perhaps this can be a step towards that, if we want.

I also expect to reuse `get_transalated_locales` for #28.

### Screenshots

Hacked a bit since these strings haven't been translated yet, but this is what the banner looks like. I can update this to match the outcome of https://github.com/WordPress/wordpress.org/issues/301.

| Homepage | Single pattern |
|--------|-------|
| ![Screen Shot 2024-05-07 at 17 38 22](https://github.com/WordPress/wporg-theme-directory/assets/541093/b1393836-bca7-4839-b30f-f19b97c5cd29) | ![Screen Shot 2024-05-07 at 17 38 16](https://github.com/WordPress/wporg-theme-directory/assets/541093/44e05501-bb43-482c-8448-5428a3adb911) |

I've tested a number of cases, here are a subset.

| Case | Result |
|---|---|
| Home/archives: English or rosetta site, no other languages requested | Empty. |
| Home/archives: English site, Spanish requested & available | The theme directory is also available in <a href="https://es.wordpress.org/themes/">Español</a>. |
| Home/archives: Rosetta site, site language (French) available, Spanish & Korean requested & available | The theme directory is also available in <a href="https://ko.wordpress.org/themes/">한국어</a> 및 <a href="https://es.wordpress.org/themes/">Español</a>. |
| Single theme: English site, no other languages requested | Empty. |
| Single theme: English site, Esperanto requested, unavailable | This theme is not translated into Esperanto yet. <a href="https://translate.wordpress.org/projects/wp-themes/neve">Help translate it!</a> |
| Single theme: English site, Spanish & Korean requested & available | `https://wordpress.org/themes/wp-json/wporg-themes/v1/locale-banner/twentytwentytwo/?new-theme=1' -H 'Accept-Language: en-US,en;q=0.8,ko-KR;q=0.5,es-ES;q=0.3` | This theme is also available in <a href="https://ko.wordpress.org/themes/twentytwentytwo/">한국어</a> 및 <a href="https://es.wordpress.org/themes/twentytwentytwo/">Español</a>. <a href="https://translate.wordpress.org/projects/wp-themes/twentytwentytwo">Help improve the translation!</a> |
| Single theme: Rosetta site, site language (Esperanto) unavailable | This theme is not translated into Esperanto yet. <a href="https://translate.wordpress.org/projects/wp-themes/neve">Help translate it!</a> |
| Single theme: Rosetta site, site language (Esperanto) unavailable, Spanish requested & available | This theme is not translated into Esperanto yet. This theme is available in <a href="https://es.wordpress.org/themes/neve/">Español</a>. <a href="https://translate.wordpress.org/projects/wp-themes/neve">Help improve the translation!</a> |
| Single theme: Rosetta site, site language (Spanish) available, Korean requested & available | This theme is also available in <a href="https://ko.wordpress.org/themes/twentytwentytwo/">한국어</a>. <a href="https://translate.wordpress.org/projects/wp-themes/twentytwentytwo">Help improve the translation!</a> |

### How to test the changes in this Pull Request:

Try out various combinations of header locale (`Accept-Language` header), theme, rosetta origin site, etc. This needs a sandbox to test for the locale database.

An example request, a single theme from the French rosetta site, with Spanish & Korean also suggested:

```
curl --socks5 localhost:8080 --resolve fr.wordpress.org:SANDBOX_IP 'https://fr.wordpress.org/themes/wp-json/wporg-themes/v1/locale-banner/twentytwentytwo/?new-theme=1' -H 'Accept-Language: en-US,en;q=0.8,ko-KR;q=0.5,es-ES;q=0.3'
```
