### PR TITLE
New block: Downloads Chart

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -12,6 +12,7 @@ require_once( __DIR__ . '/src/child-theme-notice/index.php' );
 require_once( __DIR__ . '/src/favorite-button/index.php' );
 require_once( __DIR__ . '/src/ratings-bars/index.php' );
 require_once( __DIR__ . '/src/ratings-stars/index.php' );
+require_once( __DIR__ . '/src/theme-downloads/index.php' );
 require_once( __DIR__ . '/src/theme-patterns/index.php' );
 require_once( __DIR__ . '/src/theme-previewer/index.php' );
 require_once( __DIR__ . '/src/theme-status-notice/index.php' );

--- a/source/wp-content/themes/wporg-themes-2024/patterns/single.php
+++ b/source/wp-content/themes/wporg-themes-2024/patterns/single.php
@@ -96,12 +96,14 @@
 		<!-- wp:wporg/theme-patterns /-->
 
 		<!-- wp:heading {"fontSize":"heading-4"} -->
-		<h2 class="wp-block-heading has-heading-4-font-size">Downloads per day</h2>
+		<h2 class="wp-block-heading has-heading-4-font-size"><?php esc_html_e( 'Downloads per day', 'wporg-themes' ); ?></h2>
 		<!-- /wp:heading -->
 
-		<!-- wp:paragraph -->
-		<p>[graph]</p>
+		<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"active-installs"}}}}} -->
+		<p>Active Installations</p>
 		<!-- /wp:paragraph -->
+
+		<!-- wp:wporg/theme-downloads /-->
 	</div>
 	<!-- /wp:column -->
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/block.json
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/block.json
@@ -13,5 +13,5 @@
 	},
 	"usesContext": [ "postId", "postType" ],
 	"editorScript": "file:./index.js",
-	"viewScript": [ "google-charts-loader", "jquery", "file:./view.js" ]
+	"viewScript": [ "google-charts-loader", "file:./view.js" ]
 }

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/block.json
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/block.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/theme-downloads",
+	"version": "0.1.0",
+	"title": "Downloads Chart",
+	"category": "design",
+	"icon": "",
+	"description": "",
+	"textdomain": "wporg",
+	"supports": {
+		"html": false
+	},
+	"usesContext": [ "postId", "postType" ],
+	"editorScript": "file:./index.js",
+	"viewScript": [ "google-charts-loader", "jquery", "file:./view.js" ]
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+function Edit() {
+	return <div { ...useBlockProps() }>Download chart</div>;
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.php
@@ -23,7 +23,7 @@ function init() {
 	);
 
 	// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- third-party script.
-	wp_register_script( 'google-charts-loader', 'https://www.gstatic.com/charts/loader.js', array(), null, true );
+	wp_register_script( 'google-charts-loader', 'https://www.gstatic.com/charts/loader.js', array( 'jquery' ), null, true );
 }
 
 /**

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.php
@@ -51,7 +51,7 @@ function render( $attributes, $content, $block ) {
 
 	$attribute_markup = '';
 	foreach ( $attributes as $key => $value ) {
-		$attribute_markup .= sprintf( 'data-%s="%s" ', $key, $value );
+		$attribute_markup .= sprintf( 'data-%s="%s" ', $key, esc_attr( $value ) );
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes();

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.php
@@ -42,6 +42,9 @@ function render( $attributes, $content, $block ) {
 
 	$theme_post = get_post( $block->context['postId'] );
 	$theme = wporg_themes_theme_information( $theme_post->post_name );
+	if ( isset( $theme->error ) ) {
+		return '';
+	}
 
 	$attributes = array(
 		'theme' => $theme->slug,

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Block Name: Downloads Chart
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Theme_Directory_2024\Theme_Downloads_Block;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Register the block.
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/theme-downloads',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+
+	// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- third-party script.
+	wp_register_script( 'google-charts-loader', 'https://www.gstatic.com/charts/loader.js', array(), null, true );
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! $block->context['postId'] ) {
+		return '';
+	}
+
+	$theme_post = get_post( $block->context['postId'] );
+	$theme = wporg_themes_theme_information( $theme_post->post_name );
+
+	$attributes = array(
+		'theme' => $theme->slug,
+		'label-date' => __( 'Date', 'wporg-themes' ),
+		'label-value' => __( 'Downloads', 'wporg-themes' ),
+	);
+
+	$attribute_markup = '';
+	foreach ( $attributes as $key => $value ) {
+		$attribute_markup .= sprintf( 'data-%s="%s" ', $key, $value );
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %s %s></div>',
+		$wrapper_attributes,
+		$attribute_markup
+	);
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/view.js
@@ -3,7 +3,7 @@
 async function renderChart( element ) {
 	const { theme = '', labelDate, labelValue } = element.dataset;
 	const url = 'https://api.wordpress.org/stats/themes/1.0/downloads.php?slug=' + theme + '&limit=260&callback=?';
-	let downloads;
+	let downloads = {};
 	try {
 		downloads = await jQuery.ajax( {
 			dataType: 'jsonp',

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/view.js
@@ -1,0 +1,82 @@
+/* global google, jQuery */
+
+async function renderChart( element ) {
+	const { theme = '', labelDate, labelValue } = element.dataset;
+	const url = 'https://api.wordpress.org/stats/themes/1.0/downloads.php?slug=' + theme + '&limit=260&callback=?';
+	const downloads = await jQuery.getJSON( url );
+
+	google.charts.setOnLoadCallback( function () {
+		const data = new google.visualization.DataTable();
+		let count = 0;
+
+		data.addColumn( 'string', labelDate );
+		data.addColumn( 'number', labelValue );
+
+		Object.entries( downloads ).forEach( ( [ key, value ] ) => {
+			data.addRow();
+			data.setValue( count, 0, new Date( key ).toLocaleDateString() );
+			data.setValue( count, 1, Number( value ) );
+			count++;
+		} );
+
+		new google.visualization.ColumnChart( element ).draw( data, {
+			title: 'Density of Precious Metals, in g/cm^3',
+			colors: [ '#3858e9' ],
+			fontName: 'var(--wp--preset--font-family--inter)',
+			legend: {
+				position: 'none',
+			},
+			chartArea: {
+				height: 320,
+				bottom: 60,
+				left: 60,
+				width: '100%',
+			},
+			hAxis: {
+				textStyle: {
+					color: '#1e1e1e',
+					fontSize: 10,
+				},
+			},
+			vAxis: {
+				format: '###,###',
+				textPosition: 'out',
+				viewWindowMode: 'explicit',
+				viewWindow: { min: 0 },
+				textStyle: {
+					color: '#1e1e1e',
+					fontSize: 14,
+				},
+				gridlines: {
+					color: '#d9d9d9',
+				},
+				minorGridlines: {
+					color: '#f6f6f6',
+				},
+			},
+			tooltip: {
+				textStyle: {
+					color: '#1e1e1e',
+				},
+			},
+			bar: {
+				groupWidth: data.getNumberOfRows() > 100 ? '100%' : null,
+			},
+			height: 390,
+		} );
+	} );
+}
+
+const init = () => {
+	google.charts.load( 'current', {
+		packages: [ 'corechart' ],
+	} );
+
+	const blockElements = document.querySelectorAll( '.wp-block-wporg-theme-downloads' );
+	if ( ! blockElements.length ) {
+		return;
+	}
+	blockElements.forEach( renderChart );
+};
+
+document.addEventListener( 'DOMContentLoaded', init );

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/view.js
@@ -19,8 +19,16 @@ async function renderChart( element ) {
 			count++;
 		} );
 
+		const bodyStyle = window.getComputedStyle( document.body );
+		const colors = {
+			'charcoal-1': bodyStyle.getPropertyValue( '--wp--preset--color--charcoal-1' ),
+			'blueberry-1': bodyStyle.getPropertyValue( '--wp--preset--color--blueberry-1' ),
+			'light-grey-1': bodyStyle.getPropertyValue( '--wp--preset--color--light-grey-1' ),
+			'light-grey-2': bodyStyle.getPropertyValue( '--wp--preset--color--light-grey-2' ),
+		};
+
 		new google.visualization.ColumnChart( element ).draw( data, {
-			colors: [ '#3858e9' ],
+			colors: [ colors[ 'blueberry-1' ] ],
 			fontName: 'var(--wp--preset--font-family--inter)',
 			legend: {
 				position: 'none',
@@ -33,7 +41,7 @@ async function renderChart( element ) {
 			},
 			hAxis: {
 				textStyle: {
-					color: '#1e1e1e',
+					color: colors[ 'charcoal-1' ],
 					fontSize: 10,
 				},
 			},
@@ -43,19 +51,19 @@ async function renderChart( element ) {
 				viewWindowMode: 'explicit',
 				viewWindow: { min: 0 },
 				textStyle: {
-					color: '#1e1e1e',
+					color: colors[ 'charcoal-1' ],
 					fontSize: 14,
 				},
 				gridlines: {
-					color: '#d9d9d9',
+					color: colors[ 'light-grey-1' ],
 				},
 				minorGridlines: {
-					color: '#f6f6f6',
+					color: colors[ 'light-grey-2' ],
 				},
 			},
 			tooltip: {
 				textStyle: {
-					color: '#1e1e1e',
+					color: colors[ 'charcoal-1' ],
 				},
 			},
 			bar: {

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/view.js
@@ -3,7 +3,15 @@
 async function renderChart( element ) {
 	const { theme = '', labelDate, labelValue } = element.dataset;
 	const url = 'https://api.wordpress.org/stats/themes/1.0/downloads.php?slug=' + theme + '&limit=260&callback=?';
-	const downloads = await jQuery.getJSON( url );
+	let downloads;
+	try {
+		downloads = await jQuery.ajax( {
+			dataType: 'jsonp',
+			url: url,
+		} );
+	} catch ( err ) {
+		return;
+	}
 
 	google.charts.setOnLoadCallback( function () {
 		const data = new google.visualization.DataTable();

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/view.js
@@ -20,7 +20,6 @@ async function renderChart( element ) {
 		} );
 
 		new google.visualization.ColumnChart( element ).draw( data, {
-			title: 'Density of Precious Metals, in g/cm^3',
 			colors: [ '#3858e9' ],
 			fontName: 'var(--wp--preset--font-family--inter)',
 			legend: {


### PR DESCRIPTION
Fixes #32 — Adds a new block for the download chart. This uses google charts like the current theme, with some slight styling updates (fonts, colors).

Note: This is using `jQuery.getJSON` + `jsonp` to get the data, since this endpoint doesn't have `Access-Control-Allow-Origin: *` and I was getting cors issues when using wp.apiFetch. If that's easy to fix, this can be updated to not rely on jQuery.

### Screenshots

This can show up to 260 days (columns) of data, though the chart looks best when it's much smaller than that… Perhaps a future iteration could use a line chart instead?

Brand new theme, only up for 2 days:

![Screen Shot 2024-05-09 at 18 51 02](https://github.com/WordPress/wporg-theme-directory/assets/541093/86888707-942c-441a-a4ba-a09a46e1b350)

Slightly older theme, 17 days:

![Screen Shot 2024-05-09 at 18 50 14](https://github.com/WordPress/wporg-theme-directory/assets/541093/f4e7c41d-8891-4775-9443-97c0a9b40aec)

Full 260 days of data (Twenty Twenty-Three)

![Screen Shot 2024-05-09 at 18 50 43](https://github.com/WordPress/wporg-theme-directory/assets/541093/e11ab87c-6d1d-4d58-a6f0-f89b5608b4ce)

Full 260 days of data, less popular theme, with hover state

![Screenshot 2024-05-09 at 6 59 21 PM](https://github.com/WordPress/wporg-theme-directory/assets/541093/5b55cbf7-94af-4994-ba9a-54fb565ea07b)

### How to test the changes in this Pull Request:

1. View a theme (if working locally, make sure it has a real theme slug)
2. There should be a graph on the page
3. It should match the graph on the current site, in terms of data
