### PR TITLE
Theme style variations: Update styles based on design feedback

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
@@ -36,7 +36,7 @@ function get_style_variation_card( $style ) {
 		// translators: %s pattern name.
 		'alt' => sprintf( __( 'Style: %s', 'wporg-themes' ), $style->title ),
 		'href' => $preview_link,
-		'width' => 100,
+		'width' => 130,
 		'viewportWidth' => 1180,
 		'viewportHeight' => 740,
 		'fullPage' => false,

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
@@ -52,24 +52,22 @@ $encoded_state = wp_json_encode( $init_state );
 		>
 			<div class="wp-block-button is-style-toggle is-small">
 				<button
-					tabindex="-1"
 					class="wp-block-button__link wp-element-button"
-					aria-label="Prev"
+					aria-label="<?php esc_attr_e( 'Scroll back', 'wporg-themes' ); ?>"
 					data-wp-on--click="actions.handlePrevious"
-					data-wp-bind--disabled="!state.canPrevious"
+					data-wp-bind--aria-disabled="!state.canPrevious"
 				>
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M20 11.2H6.8l3.7-3.7-1-1L3.9 12l5.6 5.5 1-1-3.7-3.7H20z"></path></svg>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z"></path></svg>
 				</button>
 			</div>
 			<div class="wp-block-button is-style-toggle is-small">
 				<button
-					tabindex="-1"
 					class="wp-block-button__link wp-element-button"
-					aria-label="Next"
+					aria-label="<?php esc_attr_e( 'Scroll forward', 'wporg-themes' ); ?>"
 					data-wp-on--click="actions.handleNext"
-					data-wp-bind--disabled="!state.canNext"
+					data-wp-bind--aria-disabled="!state.canNext"
 				>
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="m14.5 6.5-1 1 3.7 3.7H4v1.6h13.2l-3.7 3.7 1 1 5.6-5.5z"></path></svg>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"></path></svg>
 				</button>
 			</div>
 		</div>

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
@@ -18,20 +18,42 @@
 	}
 
 	.wporg-theme-style-variations__buttons {
+		display: flex;
+
+		.wp-block-button__link {
+			--wp--custom--button--spacing--padding--top: 6px !important;
+			--wp--custom--button--spacing--padding--bottom: 6px !important;
+			--wp--custom--button--spacing--padding--left: 6px !important;
+			--wp--custom--button--spacing--padding--right: 6px !important;
+		}
+
+		.wp-block-button:first-child button {
+			border-top-right-radius: 0;
+			border-bottom-right-radius: 0;
+		}
+
+		.wp-block-button:not(:first-child) button {
+			border-left: none;
+			border-top-left-radius: 0;
+			border-bottom-left-radius: 0;
+		}
+
 		svg {
 			vertical-align: middle;
-			fill: var(--wp--preset--color--charcoal-4) !important;
+			fill: currentColor !important;
 
 			html[dir="rtl"] & {
 				transform: rotate(180deg);
 			}
 		}
 
-		[disabled] {
-			pointer-events: none;
+		[aria-disabled="true"] {
+			&:hover {
+				--wp--custom--button--outline--hover--color--background: transparent !important;
+			}
 
 			svg {
-				fill: var(--wp--preset--color--charcoal-5) !important;
+				fill: var(--wp--preset--color--light-grey-1) !important;
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
@@ -39,6 +39,8 @@
 
 .wporg-theme-style-variations__row,
 .wporg-theme-style-variations__grid {
+	--wporg-theme-style-variations--size: 130px;
+
 	&:focus {
 		outline: none;
 		border-radius: 2px;
@@ -46,7 +48,7 @@
 	}
 
 	.wp-block-wporg-screenshot-preview {
-		min-width: 100px;
+		min-width: var(--wporg-theme-style-variations--size);
 
 		.wporg-screenshot-preview__container {
 			aspect-ratio: 200/125;
@@ -64,7 +66,7 @@
 	scrollbar-width: none;
 
 	.wp-block-wporg-screenshot-preview {
-		flex-basis: 100px;
+		flex-basis: var(--wporg-theme-style-variations--size);
 	}
 }
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/view.js
@@ -54,9 +54,17 @@ const { state } = store( 'wporg/themes/style-variations', {
 		init() {
 			const element = getRowElement( getElement().ref );
 			state.position = element.scrollLeft;
+			if ( ! element.children.length ) {
+				return;
+			}
+
+			const elStyle = window.getComputedStyle( element );
+			const width = parseInt( elStyle.getPropertyValue( '--wporg-theme-style-variations--size' ), 10 );
+			const gap = parseInt( elStyle.getPropertyValue( 'gap' ), 10 );
+			const fullWidth = element.children.length * width + ( element.children.length - 1 ) * gap;
+
 			// How much extra scroll overflow do we have?
-			state.overflow =
-				element.children.length * 100 + ( element.children.length - 1 ) * 10 - element.clientWidth;
+			state.overflow = fullWidth - element.clientWidth;
 		},
 		handleScroll() {
 			const element = getRowElement( getElement().ref );


### PR DESCRIPTION
This PR combines the style variation feedback.
- Updates the size of the style variation screenshot (#60)
- Makes the arrow controls focusable and switches to `aria-disabled` so that they can stay focusable (#59)
- Update the look of the arrow buttons (#61)

Fixes #59, fixes #60, fixes #61.

### Screenshots

Mouse and keyboard interactions:

https://github.com/WordPress/wporg-theme-directory/assets/541093/b4a075d0-70f8-4c5a-ba32-7939b405c9e8
