### PR TITLE
New block: Theme settings for owners to control community/commercial URLs

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -15,6 +15,7 @@ require_once( __DIR__ . '/src/ratings-stars/index.php' );
 require_once( __DIR__ . '/src/theme-downloads/index.php' );
 require_once( __DIR__ . '/src/theme-patterns/index.php' );
 require_once( __DIR__ . '/src/theme-previewer/index.php' );
+require_once( __DIR__ . '/src/theme-settings/index.php' );
 require_once( __DIR__ . '/src/theme-status-notice/index.php' );
 require_once( __DIR__ . '/src/theme-style-variations/index.php' );
 require_once( __DIR__ . '/src/theme-style-variations-items/index.php' );

--- a/source/wp-content/themes/wporg-themes-2024/patterns/single.php
+++ b/source/wp-content/themes/wporg-themes-2024/patterns/single.php
@@ -104,6 +104,8 @@
 		<!-- /wp:paragraph -->
 
 		<!-- wp:wporg/theme-downloads /-->
+
+		<!-- wp:wporg/theme-settings /-->
 	</div>
 	<!-- /wp:column -->
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-settings/block.json
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-settings/block.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/theme-settings",
+	"version": "0.1.0",
+	"title": "Theme Settings",
+	"category": "design",
+	"icon": "",
+	"description": "Settings for the theme owner.",
+	"textdomain": "wporg",
+	"supports": {
+		"html": false
+	},
+	"usesContext": [ "postId", "postType" ],
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css",
+	"viewScriptModule": "file:./view.js",
+	"render": "file:./render.php"
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-settings/index.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-settings/index.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from '../utils/dynamic-edit';
+import metadata from './block.json';
+import './style.scss';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-settings/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-settings/index.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Block Name: Theme Settings
+ * Description: Settings for the theme owner.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Theme_Directory_2024\Theme_Settings_Block;
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Register the block.
+ */
+function init() {
+	register_block_type( __DIR__ . '/../../build/theme-settings' );
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-settings/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-settings/render.php
@@ -24,19 +24,17 @@ if ( ! $model_type || ! current_user_can( 'edit_post', $theme_post->ID ) ) {
 
 // Enqueue this script, so that it's available for the interactivity view script.
 wp_enqueue_script( 'wp-api-fetch' );
-// Enqueue the notice style so the markup is styled correctly.
-wp_enqueue_style( 'wporg-notice-style' );
 
 $labels = [
 	'heading' => __( 'Theme options', 'wporg-themes' ),
 ];
 if ( 'community' === $model_type ) {
-	$labels['type'] = __( 'Community theme', 'wporg-themes' );
+	$labels['type'] = __( 'Community theme:', 'wporg-themes' );
 	$labels['description'] = __( 'This theme is developed and supported by a community.', 'wporg-themes' );
 	$labels['form_label'] = __( 'Development repository URL', 'wporg-themes' );
 	$labels['form_help'] = __( 'Optional. The URL where development happens, such as at github.com.', 'wporg-themes' );
 } elseif ( 'commercial' === $model_type ) {
-	$labels['type'] = __( 'Commercial theme', 'wporg-themes' );
+	$labels['type'] = __( 'Commercial theme:', 'wporg-themes' );
 	$labels['description'] = __( 'This theme is free but offers paid upgrades, support, and/or add-ons.', 'wporg-themes' );
 	$labels['form_label'] = __( 'Commercial support URL', 'wporg-themes' );
 	$labels['form_help'] = __( 'Optional. The URL for theme support, other than its support forum on wordpress.org.', 'wporg-themes' );
@@ -48,7 +46,7 @@ $init_state = [
 	'type' => $model_type,
 	'url' => $url,
 	'labels' => [
-		'success' => __( 'Saved!', 'wporg-themes' ),
+		'success' => __( 'URL saved correctly!', 'wporg-themes' ),
 		'error' => __( 'Error updating the URL. Please try again.', 'wporg-themes' ),
 	],
 ];
@@ -61,15 +59,10 @@ $encoded_state = wp_json_encode( $init_state );
 	data-wp-context="<?php echo esc_attr( $encoded_state ); ?>"
 >
 	<h2 class="has-heading-4-font-size"><?php echo esc_html( $labels['heading'] ); ?></h2>
-	<div class="wp-block-wporg-notice is-info-notice">
-		<div class="wp-block-wporg-notice__icon"></div>
-		<div class="wp-block-wporg-notice__content">
-			<p class="wporg-theme-settings__description">
-				<strong><?php echo esc_html( $labels['type'] ); ?></strong><br />
-				<?php echo esc_html( $labels['description'] ); ?>
-			</p>
-		</div>
-	</div>
+	<p class="wporg-theme-settings__description">
+		<strong><?php echo esc_html( $labels['type'] ); ?></strong>
+		<?php echo esc_html( $labels['description'] ); ?>
+	</p>
 	<form data-wp-on--submit="actions.onSubmit" method="POST">
 		<div class="wporg-theme-settings__url-field">
 			<label for="wporg-theme-settings-url"><?php echo esc_html( $labels['form_label'] ); ?></label>
@@ -82,8 +75,8 @@ $encoded_state = wp_json_encode( $init_state );
 				data-wp-bind--value="context.url"
 				data-wp-on--keydown="actions.onChange"
 			/>
+			<p class="wporg-theme-settings__form-help" id="wporg-theme-settings__form-help"><?php echo esc_html( $labels['form_help'] ); ?></p>
 		</div>
-		<p class="wporg-theme-settings__form-help" id="wporg-theme-settings__form-help"><?php echo esc_html( $labels['form_help'] ); ?></p>
 		<div class="wporg-theme-settings__button wp-block-button is-small">
 			<button
 				class="wp-block-button__link wp-element-button"

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-settings/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-settings/render.php
@@ -1,0 +1,99 @@
+<?php
+
+if ( ! $block->context['postId'] ) {
+	return '';
+}
+
+$theme_post = get_post( $block->context['postId'] );
+
+$model_type = false;
+$url = '';
+
+if ( has_term( 'commercial', 'theme_business_model', $theme_post ) ) {
+	$model_type = 'commercial';
+	$url = get_post_meta( $theme_post->ID, 'external_support_url', true );
+} elseif ( has_term( 'community', 'theme_business_model', $theme_post ) ) {
+	$model_type = 'community';
+	$url = get_post_meta( $theme_post->ID, 'external_repository_url', true );
+}
+
+// Not community/commercial, or the user is not an owner/admin.
+if ( ! $model_type || ! current_user_can( 'edit_post', $theme_post->ID ) ) {
+	return;
+}
+
+// Enqueue this script, so that it's available for the interactivity view script.
+wp_enqueue_script( 'wp-api-fetch' );
+// Enqueue the notice style so the markup is styled correctly.
+wp_enqueue_style( 'wporg-notice-style' );
+
+$labels = [
+	'heading' => __( 'Theme options', 'wporg-themes' ),
+];
+if ( 'community' === $model_type ) {
+	$labels['type'] = __( 'Community theme', 'wporg-themes' );
+	$labels['description'] = __( 'This theme is developed and supported by a community.', 'wporg-themes' );
+	$labels['form_label'] = __( 'Development repository URL', 'wporg-themes' );
+	$labels['form_help'] = __( 'Optional. The URL where development happens, such as at github.com.', 'wporg-themes' );
+} elseif ( 'commercial' === $model_type ) {
+	$labels['type'] = __( 'Commercial theme', 'wporg-themes' );
+	$labels['description'] = __( 'This theme is free but offers paid upgrades, support, and/or add-ons.', 'wporg-themes' );
+	$labels['form_label'] = __( 'Commercial support URL', 'wporg-themes' );
+	$labels['form_help'] = __( 'Optional. The URL for theme support, other than its support forum on wordpress.org.', 'wporg-themes' );
+}
+
+// Initial state to pass to Interactivity API.
+$init_state = [
+	'slug' => $theme_post->post_name,
+	'type' => $model_type,
+	'url' => $url,
+	'labels' => [
+		'success' => __( 'Saved!', 'wporg-themes' ),
+		'error' => __( 'Error updating the URL. Please try again.', 'wporg-themes' ),
+	],
+];
+$encoded_state = wp_json_encode( $init_state );
+
+?>
+<div
+	<?php echo get_block_wrapper_attributes(); // phpcs:ignore ?>
+	data-wp-interactive="wporg/themes/theme-settings"
+	data-wp-context="<?php echo esc_attr( $encoded_state ); ?>"
+>
+	<h2 class="has-heading-4-font-size"><?php echo esc_html( $labels['heading'] ); ?></h2>
+	<div class="wp-block-wporg-notice is-info-notice">
+		<div class="wp-block-wporg-notice__icon"></div>
+		<div class="wp-block-wporg-notice__content">
+			<p class="wporg-theme-settings__description">
+				<strong><?php echo esc_html( $labels['type'] ); ?></strong><br />
+				<?php echo esc_html( $labels['description'] ); ?>
+			</p>
+		</div>
+	</div>
+	<form data-wp-on--submit="actions.onSubmit" method="POST">
+		<div class="wporg-theme-settings__url-field">
+			<label for="wporg-theme-settings-url"><?php echo esc_html( $labels['form_label'] ); ?></label>
+			<input
+				id="wporg-theme-settings-url"
+				aria-describedby="wporg-theme-settings__form-help"
+				type="url"
+				name="url"
+				value="<?php echo esc_attr( $url ); ?>"
+				data-wp-bind--value="context.url"
+				data-wp-on--keydown="actions.onChange"
+			/>
+		</div>
+		<p class="wporg-theme-settings__form-help" id="wporg-theme-settings__form-help"><?php echo esc_html( $labels['form_help'] ); ?></p>
+		<div class="wporg-theme-settings__button wp-block-button is-small">
+			<button
+				class="wp-block-button__link wp-element-button"
+				data-wp-bind--aria-disabled="state.isSubmitting"
+			>
+				<?php esc_html_e( 'Save', 'wporg-themes' ); ?>
+			</button>
+			<div aria-live="polite" aria-atomic="true">
+				<span data-wp-text="state.resultMessage"></span>
+			</div>
+		</div>
+	</form>
+</div>

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-settings/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-settings/style.scss
@@ -49,5 +49,6 @@
 		margin: 0;
 		font-size: var(--wp--preset--font-size--small);
 		line-height: var(--wp--custom--body--small--typography--line-height);
+		color: var(--wp--preset--color--charcoal-4);
 	}
 }

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-settings/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-settings/style.scss
@@ -1,0 +1,58 @@
+.wp-block-wporg-theme-settings {
+	--wp--custom--form--border--width: 1px;
+	--wp--custom--form--border--color: var(--wp--preset--color--light-grey-1);
+
+	border-top: 1px solid var(--wp--preset--color--light-grey-1);
+	margin-top: var(--wp--preset--spacing--30);
+	padding-top: var(--wp--preset--spacing--30);
+
+	h2 {
+		margin: 0;
+	}
+
+	> *,
+	form > * {
+		margin: 0;
+	}
+
+	> * + * {
+		margin-top: var(--wp--preset--spacing--20);
+	}
+
+	.wporg-theme-settings__button {
+		display: flex;
+		margin-top: var(--wp--preset--spacing--20);
+		gap: var(--wp--preset--spacing--20);
+		align-items: center;
+
+		[aria-disabled="true"] {
+			pointer-events: none;
+			--wp--custom--button--color--background: var(--wp--preset--color--charcoal-4);
+		}
+	}
+}
+
+.wporg-theme-settings__url-field {
+	display: flex;
+	flex-direction: column;
+
+	label {
+		margin-bottom: calc(var(--wp--preset--spacing--10) * 0.4);
+	}
+
+	input {
+		width: 100%;
+		max-width: 50ch;
+
+		&:focus {
+			outline: 1.5px solid var(--wp--preset--color--blueberry-1);
+			outline-offset: -1.5px;
+			border-color: transparent;
+		}
+	}
+}
+
+.wporg-theme-settings__form-help {
+	font-size: var(--wp--preset--font-size--small);
+	line-height: var(--wp--custom--body--small--typography--line-height);
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-settings/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-settings/style.scss
@@ -1,10 +1,8 @@
 .wp-block-wporg-theme-settings {
 	--wp--custom--form--border--width: 1px;
-	--wp--custom--form--border--color: var(--wp--preset--color--light-grey-1);
+	--wp--custom--form--border--color: var(--wp--preset--color--charcoal-5);
 
-	border-top: 1px solid var(--wp--preset--color--light-grey-1);
-	margin-top: var(--wp--preset--spacing--30);
-	padding-top: var(--wp--preset--spacing--30);
+	margin-top: var(--wp--preset--spacing--40);
 
 	h2 {
 		margin: 0;
@@ -35,14 +33,10 @@
 .wporg-theme-settings__url-field {
 	display: flex;
 	flex-direction: column;
-
-	label {
-		margin-bottom: calc(var(--wp--preset--spacing--10) * 0.4);
-	}
+	gap: calc(var(--wp--preset--spacing--10) * 0.6);
 
 	input {
 		width: 100%;
-		max-width: 50ch;
 
 		&:focus {
 			outline: 1.5px solid var(--wp--preset--color--blueberry-1);
@@ -50,9 +44,10 @@
 			border-color: transparent;
 		}
 	}
-}
 
-.wporg-theme-settings__form-help {
-	font-size: var(--wp--preset--font-size--small);
-	line-height: var(--wp--custom--body--small--typography--line-height);
+	.wporg-theme-settings__form-help {
+		margin: 0;
+		font-size: var(--wp--preset--font-size--small);
+		line-height: var(--wp--custom--body--small--typography--line-height);
+	}
 }

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-settings/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-settings/view.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { getContext, store } from '@wordpress/interactivity';
+
+const { state } = store( 'wporg/themes/theme-settings', {
+	state: {
+		isError: false,
+		isSuccess: false,
+		isSubmitting: false,
+		get resultMessage() {
+			const { labels } = getContext();
+			if ( state.isSuccess ) {
+				return labels.success;
+			}
+			if ( state.isError ) {
+				return labels.error;
+			}
+			return '';
+		},
+	},
+	actions: {
+		onChange() {
+			state.isSuccess = false;
+			state.isError = false;
+		},
+		*onSubmit( event ) {
+			event.preventDefault();
+			const context = getContext();
+			const { type, slug, url } = context;
+			const inputEl = event.target.elements.url;
+			if ( ! inputEl ) {
+				return;
+			}
+			const newUrl = inputEl.value;
+			state.isSubmitting = true;
+			try {
+				const key = 'commercial' === type ? 'supportURL' : 'repositoryURL';
+				const response = yield wp.apiFetch( {
+					path: '/themes/v1/theme/' + slug + '/' + type,
+					method: 'POST',
+					data: { [ key ]: newUrl },
+				} );
+				if ( typeof response[ key ] === 'undefined' ) {
+					throw new Error( 'Invalid response from API.' );
+				}
+				context.url = response[ key ];
+				state.isSuccess = true;
+			} catch ( error ) {
+				inputEl.value = url;
+				state.isError = true;
+			}
+			state.isSubmitting = false;
+		},
+	},
+} );


### PR DESCRIPTION
This creates a single new block for theme owners to configure settings related to their theme. Currently the only option is the URL for either support (commercial themes) or a development repo (community themes).

Fixes #34, fixes #35 

### Screenshots

Before

| Community | Commercial |
|---|---|
| ![Image](https://github.com/WordPress/wporg-theme-directory/assets/541093/405216db-8900-49c4-8547-f17c6651e5a0) | ![Image](https://github.com/WordPress/wporg-theme-directory/assets/541093/792d2ba1-26e0-42fc-859d-ab6547506166) |

After

| Community | Commercial | Neither |
|--------|-------|---|
| ![theme-community](https://github.com/WordPress/wporg-theme-directory/assets/541093/c2dc57b6-90a9-4ec6-b8c8-f7b222f011f1) | ![theme-commercial](https://github.com/WordPress/wporg-theme-directory/assets/541093/23d5c4ce-d017-40c2-983f-e36ee4affde2) | ![theme-none](https://github.com/WordPress/wporg-theme-directory/assets/541093/71404cb4-779f-44c1-8ccf-88dbba7e0e27) |

When saving, the form submits to the API and adds a message next to the button. This message is also announced to screen readers. It does not automatically update the URL at the top of the page, if this is confusing we could possibly add a note to reload the page?

| Success | Error |
|--------|-------|
| <img width="836" alt="Screenshot 2024-05-15 at 5 50 55 PM" src="https://github.com/WordPress/wporg-theme-directory/assets/541093/5e3eb47e-91e8-4d1f-b80f-09445c4bf592"> | <img width="827" alt="Screenshot 2024-05-15 at 5 51 26 PM" src="https://github.com/WordPress/wporg-theme-directory/assets/541093/f5e56854-e34c-4f9a-a3a9-1c8f3e100f0b"> |

### How to test the changes in this Pull Request:

1. View a community theme either as the theme owner or a side admin/moderator
2. You should see the "Theme options" section
3. Update the field
4. It should only accept URLs (browser input validation)
5. Reloading the page, the "Contribute to this theme" link should use the new URL
6. Repeat testing on a commercial theme
