### PR TITLE
New block: "Available translations" to list other translations for a theme

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -12,6 +12,7 @@ require_once( __DIR__ . '/src/child-theme-notice/index.php' );
 require_once( __DIR__ . '/src/favorite-button/index.php' );
 require_once( __DIR__ . '/src/ratings-bars/index.php' );
 require_once( __DIR__ . '/src/ratings-stars/index.php' );
+require_once( __DIR__ . '/src/theme-available-translations/index.php' );
 require_once( __DIR__ . '/src/theme-downloads/index.php' );
 require_once( __DIR__ . '/src/theme-patterns/index.php' );
 require_once( __DIR__ . '/src/theme-previewer/index.php' );

--- a/source/wp-content/themes/wporg-themes-2024/patterns/single.php
+++ b/source/wp-content/themes/wporg-themes-2024/patterns/single.php
@@ -157,6 +157,8 @@
 		<h2 class="wp-block-heading has-heading-4-font-size"><?php esc_html_e( 'Translations', 'wporg-themes' ); ?></h2>
 		<!-- /wp:heading -->
 
+		<!-- wp:wporg/theme-available-translations /-->
+
 		<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"translate-link"}}}}} -->
 		<p>Translate this theme</p>
 		<!-- /wp:paragraph -->

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-available-translations/block.json
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-available-translations/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/theme-available-translations",
+	"version": "0.1.0",
+	"title": "Available translations",
+	"category": "design",
+	"icon": "",
+	"description": "A list of the available translations for this theme.",
+	"textdomain": "wporg",
+	"supports": {
+		"html": false
+	},
+	"usesContext": [ "postId", "postType" ],
+	"editorScript": "file:./index.js"
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-available-translations/index.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-available-translations/index.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Edit from '../utils/dynamic-edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-available-translations/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-available-translations/index.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Block Name: Available translations
+ * Description: A list of the available translations for this theme.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Theme_Directory_2024\Theme_Available_Translations_Block;
+
+use function WordPressdotorg\MU_Plugins\Helpers\Locale\{ get_all_locales_with_subdomain, get_translated_locales };
+
+defined( 'WPINC' ) || die();
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Register the block.
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/theme-available-translations',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! $block->context['postId'] || ! defined( 'GLOTPRESS_LOCALES_PATH' ) ) {
+		return '';
+	}
+
+	$theme_post = get_post( $block->context['postId'] );
+	$theme = wporg_themes_theme_information( $theme_post->post_name );
+	if ( isset( $theme->error ) ) {
+		return '';
+	}
+
+	$languages = get_language_links( $theme->slug );
+
+	if ( empty( $languages ) ) {
+		return '';
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %s>%s</div>',
+		$wrapper_attributes,
+		sprintf(
+			// translators: %s is a list of links to the theme in each language.
+			esc_html__( 'This theme is available in the following languages: %s', 'wporg-themes' ),
+			wp_sprintf( '%l.', $languages )
+		)
+	);
+}
+
+/**
+ * Get an array of links to Rosetta sites where this theme is translated.
+ */
+function get_language_links( $slug ) {
+	$locale_subdomain_assoc = get_all_locales_with_subdomain();
+	$translated_locales = get_translated_locales( 'theme', $slug );
+
+	$available_languages = array();
+	foreach ( $translated_locales as $locale ) {
+		if ( isset( $locale_subdomain_assoc[ $locale ] ) ) {
+			$language = \GP_Locales::by_field( 'wp_locale', $locale )->native_name;
+			$available_languages[ $locale ] = sprintf(
+				'<a href="https://%s.wordpress.org%s">%s</a>',
+				$locale_subdomain_assoc[ $locale ]->subdomain,
+				esc_url( trailingslashit( get_site()->path . $slug ) ),
+				$language
+			);
+		}
+	}
+
+	// Add in an "English (US)" link back to the main site.
+	if ( $available_languages || 'en_US' !== get_locale() ) {
+		$available_languages['en_US'] = sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( trailingslashit( 'https://wordpress.org/themes/' . $slug ) ),
+			'English (US)', // Not translated, locale name is in native language.
+		);
+	}
+
+	ksort( $available_languages, SORT_NATURAL );
+
+	return $available_languages;
+}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-available-translations/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-available-translations/index.php
@@ -74,12 +74,14 @@ function get_language_links( $slug ) {
 	$available_languages = array();
 	foreach ( $translated_locales as $locale ) {
 		if ( isset( $locale_subdomain_assoc[ $locale ] ) ) {
-			$language = \GP_Locales::by_field( 'wp_locale', $locale )->native_name;
+			$language = \GP_Locales::by_field( 'wp_locale', $locale );
+
 			$available_languages[ $locale ] = sprintf(
-				'<a href="https://%s.wordpress.org%s">%s</a>',
+				'<a href="https://%1$s.wordpress.org%2$s" lang="%3$s">%4$s</a>',
 				$locale_subdomain_assoc[ $locale ]->subdomain,
 				esc_url( trailingslashit( get_site()->path . $slug ) ),
-				$language
+				$language->slug,
+				$language->native_name
 			);
 		}
 	}
@@ -87,7 +89,7 @@ function get_language_links( $slug ) {
 	// Add in an "English (US)" link back to the main site.
 	if ( $available_languages || 'en_US' !== get_locale() ) {
 		$available_languages['en_US'] = sprintf(
-			'<a href="%1$s">%2$s</a>',
+			'<a href="%1$s" lang="en-US">%2$s</a>',
 			esc_url( trailingslashit( 'https://wordpress.org/themes/' . $slug ) ),
 			'English (US)', // Not translated, locale name is in native language.
 		);


### PR DESCRIPTION
Fixes #28 — This adds a new block into the "Translations" section of the single theme sidebar, to list out all of the available languages for a given theme.

This is similar to what's on plugins, but I intentionally did not put it behind a dropdown (we can't reuse the plugins one, and it's not a true modal anyway). TBH I think having the full list is a good indicator of "theme health" — if a theme has been translated into many languages, people clearly thought it was worth translating for whatever reason.

### Screenshots

On a theme with many translations (Twenty Nineteen).

![theme-many-translations](https://github.com/WordPress/wporg-theme-directory/assets/541093/ddd4d097-7455-4abe-a6e4-a74636ffeef1)

On a theme with a few translations.

![theme-few-translations](https://github.com/WordPress/wporg-theme-directory/assets/541093/9a54ea24-60fd-4c74-80f0-56e761e366bb)

On a theme with no translations. No message appears when viewing from the English site, just the "translate" link.

![theme-no-translations](https://github.com/WordPress/wporg-theme-directory/assets/541093/01a6b25f-e7bc-4e7d-b26d-a988432c23c7)

Same theme, but viewed from a Rosetta site, links back to the main English site. No message about it not being supported in whatever you're viewing from, but the banner takes care of that with "This theme is not translated into Español yet. [Help translate it!](https://translate.wordpress.org/projects/wp-themes/museum)"

![theme-no-translations-es](https://github.com/WordPress/wporg-theme-directory/assets/541093/6f8cfb49-8b42-4825-876a-80ee50ba207b)

### How to test the changes in this Pull Request:

Requires a sandbox for the locale database.

View a theme with active translations, they should be linked in the sidebar. Clicking the link takes you to the theme page on that Rosetta site.
