### PR TITLE
i18n: Use translations for theme name, content, terms, and page title

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,0 +1,27 @@
+name: Translate Strings
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6,18 * * *'
+
+jobs:
+  translation-strings:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: i18n
+        uses: WordPress/wporg-repo-tools/.github/actions/i18n@try/i18n-action
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --taxonomies=post_tag,category --post_types=page --url=https://wordpress.org/themes/wp-json/wp/v2/ --textdomain=wporg-themes
+
+      - name: Commit and push
+        # Using a specific hash here instead of a tagged version, for risk mitigation, since this action modifies our repo.
+        uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
+        with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            branch: trunk
+            message: 'Update translation strings'

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -2,6 +2,9 @@ name: Translate Strings
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - update/use-theme-obj-for-i18n
   schedule:
     - cron: '0 6,18 * * *'
 
@@ -23,5 +26,5 @@ jobs:
         uses: actions-js/push@a52398fac807b0c1e5f1492c969b477c8560a0ba # 1.3
         with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
-            branch: trunk
+            branch: update/use-theme-obj-for-i18n
             message: 'Update translation strings'

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -19,7 +19,7 @@ jobs:
         uses: WordPress/wporg-repo-tools/.github/actions/i18n@try/i18n-action
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --taxonomies=post_tag,category --post_types=page --url=https://wordpress.org/themes/wp-json/wp/v2/ --textdomain=wporg-themes
+          args: --taxonomies=post_tag --post_types=page --url=https://wordpress.org/themes/wp-json/wp/v2/ --textdomain=wporg-themes
 
       - name: Commit and push
         # Using a specific hash here instead of a tagged version, for risk mitigation, since this action modifies our repo.

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -19,7 +19,7 @@ jobs:
         uses: WordPress/wporg-repo-tools/.github/actions/i18n@try/i18n-action
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --taxonomies=post_tag --post_types=page --url=https://wordpress.org/themes/wp-json/wp/v2/ --textdomain=wporg-themes
+          args: --no_taxonomies --post_types=page --url=https://wordpress.org/themes/wp-json/wp/v2/ --textdomain=wporg-themes
 
       - name: Commit and push
         # Using a specific hash here instead of a tagged version, for risk mitigation, since this action modifies our repo.

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: i18n
-        uses: WordPress/wporg-repo-tools/.github/actions/i18n@try/i18n-action
+        uses: WordPress/wporg-repo-tools/.github/actions/i18n@trunk
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --no_taxonomies --post_types=page --url=https://wordpress.org/themes/wp-json/wp/v2/ --textdomain=wporg-themes

--- a/extra/translation-strings.php
+++ b/extra/translation-strings.php
@@ -1,0 +1,16 @@
+<?php
+// phpcs:disable
+/**
+ * Generated file for translation strings.
+ *
+ * Used to import additional strings into the GlotPress translation project.
+ *
+ * ⚠️ This is a generated file. Do not edit manually. See bin/i18n.php.
+ * ⚠️ Do not require or include this file anywhere.
+ */
+
+_x( 'Review Stats', 'page title', 'wporg-themes' );
+_x( 'Getting Started', 'page title', 'wporg-themes' );
+_x( 'Submit Your Theme or Theme Update to the Directory', 'page title', 'wporg-themes' );
+_x( 'About', 'page title', 'wporg-themes' );
+_x( 'Commercially Supported GPL Themes', 'page title', 'wporg-themes' );

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -392,7 +392,8 @@ function get_tag_labels( $tags ) {
 }
 
 /**
- * Get all possible features, using the default textdomain to mirror WP core.
+ * Get all possible features. This list mirrors core, but needs the local
+ * textdomain as the terms have been updated to be sentence-case.
  *
  * @param string $include Optional. Type of list: 'active', 'deprecated' or 'all'. Default 'active'.
  * @param string $subset  Optional. Returns only the selected subset of features.
@@ -402,120 +403,118 @@ function get_tag_labels( $tags ) {
 function wporg_themes_get_feature_list( $include = 'active', $subset = '' ) {
 	$features = array();
 
-	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- Intentionally uses core textdomain.
 	if ( 'active' === $include || 'all' === $include ) {
 		$features = array(
-			__( 'Layout' )   => array(
-				'grid-layout'   => __( 'Grid layout' ),
-				'one-column'    => __( 'One column' ),
-				'two-columns'   => __( 'Two columns' ),
-				'three-columns' => __( 'Three columns' ),
-				'four-columns'  => __( 'Four columns' ),
-				'left-sidebar'  => __( 'Left sidebar' ),
-				'right-sidebar' => __( 'Right sidebar' ),
-				'wide-blocks'   => __( 'Wide blocks' ),
+			__( 'Layout', 'wporg-themes' )   => array(
+				'grid-layout'   => __( 'Grid layout', 'wporg-themes' ),
+				'one-column'    => __( 'One column', 'wporg-themes' ),
+				'two-columns'   => __( 'Two columns', 'wporg-themes' ),
+				'three-columns' => __( 'Three columns', 'wporg-themes' ),
+				'four-columns'  => __( 'Four columns', 'wporg-themes' ),
+				'left-sidebar'  => __( 'Left sidebar', 'wporg-themes' ),
+				'right-sidebar' => __( 'Right sidebar', 'wporg-themes' ),
+				'wide-blocks'   => __( 'Wide blocks', 'wporg-themes' ),
 			),
-			__( 'Features' ) => array(
-				'accessibility-ready'   => __( 'Accessibility ready' ),
-				'block-patterns'        => __( 'Block editor patterns' ),
-				'block-styles'          => __( 'Block editor styles' ),
-				'full-site-editing'     => __( 'Block themes' ),
-				'buddypress'            => __( 'BuddyPress' ),
-				'custom-background'     => __( 'Custom background' ),
-				'custom-colors'         => __( 'Custom colors' ),
-				'custom-header'         => __( 'Custom header' ),
-				'custom-logo'           => __( 'Custom logo' ),
-				'custom-menu'           => __( 'Custom menu' ),
-				'editor-style'          => __( 'Editor style' ),
-				'featured-image-header' => __( 'Featured image header' ),
-				'featured-images'       => __( 'Featured images' ),
-				'flexible-header'       => __( 'Flexible header' ),
-				'footer-widgets'        => __( 'Footer widgets' ),
-				'front-page-post-form'  => __( 'Front page posting' ),
-				'full-width-template'   => __( 'Full width template' ),
-				'microformats'          => __( 'Microformats' ),
-				'post-formats'          => __( 'Post formats' ),
-				'rtl-language-support'  => __( 'RTL language support' ),
-				'sticky-post'           => __( 'Sticky post' ),
-				'style-variations'      => __( 'Style variations' ),
-				'template-editing'      => __( 'Template editing' ),
-				'theme-options'         => __( 'Theme options' ),
-				'threaded-comments'     => __( 'Threaded comments' ),
-				'translation-ready'     => __( 'Translation ready' ),
+			__( 'Features', 'wporg-themes' ) => array(
+				'accessibility-ready'   => __( 'Accessibility ready', 'wporg-themes' ),
+				'block-patterns'        => __( 'Block editor patterns', 'wporg-themes' ),
+				'block-styles'          => __( 'Block editor styles', 'wporg-themes' ),
+				'full-site-editing'     => __( 'Block themes', 'wporg-themes' ),
+				'buddypress'            => __( 'BuddyPress', 'wporg-themes' ),
+				'custom-background'     => __( 'Custom background', 'wporg-themes' ),
+				'custom-colors'         => __( 'Custom colors', 'wporg-themes' ),
+				'custom-header'         => __( 'Custom header', 'wporg-themes' ),
+				'custom-logo'           => __( 'Custom logo', 'wporg-themes' ),
+				'custom-menu'           => __( 'Custom menu', 'wporg-themes' ),
+				'editor-style'          => __( 'Editor style', 'wporg-themes' ),
+				'featured-image-header' => __( 'Featured image header', 'wporg-themes' ),
+				'featured-images'       => __( 'Featured images', 'wporg-themes' ),
+				'flexible-header'       => __( 'Flexible header', 'wporg-themes' ),
+				'footer-widgets'        => __( 'Footer widgets', 'wporg-themes' ),
+				'front-page-post-form'  => __( 'Front page posting', 'wporg-themes' ),
+				'full-width-template'   => __( 'Full width template', 'wporg-themes' ),
+				'microformats'          => __( 'Microformats', 'wporg-themes' ),
+				'post-formats'          => __( 'Post formats', 'wporg-themes' ),
+				'rtl-language-support'  => __( 'RTL language support', 'wporg-themes' ),
+				'sticky-post'           => __( 'Sticky post', 'wporg-themes' ),
+				'style-variations'      => __( 'Style variations', 'wporg-themes' ),
+				'template-editing'      => __( 'Template editing', 'wporg-themes' ),
+				'theme-options'         => __( 'Theme options', 'wporg-themes' ),
+				'threaded-comments'     => __( 'Threaded comments', 'wporg-themes' ),
+				'translation-ready'     => __( 'Translation ready', 'wporg-themes' ),
 			),
-			__( 'Subject' )  => array(
-				'blog'           => __( 'Blog' ),
-				'e-commerce'     => __( 'E-commerce' ),
-				'education'      => __( 'Education' ),
-				'entertainment'  => __( 'Entertainment' ),
-				'food-and-drink' => __( 'Food & drink' ),
-				'holiday'        => __( 'Holiday' ),
-				'news'           => __( 'News' ),
-				'photography'    => __( 'Photography' ),
-				'portfolio'      => __( 'Portfolio' ),
+			__( 'Subject', 'wporg-themes' )  => array(
+				'blog'           => __( 'Blog', 'wporg-themes' ),
+				'e-commerce'     => __( 'E-commerce', 'wporg-themes' ),
+				'education'      => __( 'Education', 'wporg-themes' ),
+				'entertainment'  => __( 'Entertainment', 'wporg-themes' ),
+				'food-and-drink' => __( 'Food & drink', 'wporg-themes' ),
+				'holiday'        => __( 'Holiday', 'wporg-themes' ),
+				'news'           => __( 'News', 'wporg-themes' ),
+				'photography'    => __( 'Photography', 'wporg-themes' ),
+				'portfolio'      => __( 'Portfolio', 'wporg-themes' ),
 			),
 		);
 	}
 
 	if ( 'deprecated' === $include || 'all' === $include ) {
-		$features[ __( 'Colors' ) ] = array(
-			'black'  => __( 'Black' ),
-			'blue'   => __( 'Blue' ),
-			'brown'  => __( 'Brown' ),
-			'gray'   => __( 'Gray' ),
-			'green'  => __( 'Green' ),
-			'orange' => __( 'Orange' ),
-			'pink'   => __( 'Pink' ),
-			'purple' => __( 'Purple' ),
-			'red'    => __( 'Red' ),
-			'silver' => __( 'Silver' ),
-			'tan'    => __( 'Tan' ),
-			'white'  => __( 'White' ),
-			'yellow' => __( 'Yellow' ),
-			'dark'   => __( 'Dark' ),
-			'light'  => __( 'Light' ),
+		$features[ __( 'Colors', 'wporg-themes' ) ] = array(
+			'black'  => __( 'Black', 'wporg-themes' ),
+			'blue'   => __( 'Blue', 'wporg-themes' ),
+			'brown'  => __( 'Brown', 'wporg-themes' ),
+			'gray'   => __( 'Gray', 'wporg-themes' ),
+			'green'  => __( 'Green', 'wporg-themes' ),
+			'orange' => __( 'Orange', 'wporg-themes' ),
+			'pink'   => __( 'Pink', 'wporg-themes' ),
+			'purple' => __( 'Purple', 'wporg-themes' ),
+			'red'    => __( 'Red', 'wporg-themes' ),
+			'silver' => __( 'Silver', 'wporg-themes' ),
+			'tan'    => __( 'Tan', 'wporg-themes' ),
+			'white'  => __( 'White', 'wporg-themes' ),
+			'yellow' => __( 'Yellow', 'wporg-themes' ),
+			'dark'   => __( 'Dark', 'wporg-themes' ),
+			'light'  => __( 'Light', 'wporg-themes' ),
 		);
 
 		if ( 'deprecated' === $include ) {
 			// Initialize arrays.
-			$features[ __( 'Layout' ) ]   = array();
-			$features[ __( 'Features' ) ] = array();
-			$features[ __( 'Subject' ) ]  = array();
+			$features[ __( 'Layout', 'wporg-themes' ) ]   = array();
+			$features[ __( 'Features', 'wporg-themes' ) ] = array();
+			$features[ __( 'Subject', 'wporg-themes' ) ]  = array();
 		}
 
-		$features[ __( 'Layout' ) ] = array_merge(
-			$features[ __( 'Layout' ) ],
+		$features[ __( 'Layout', 'wporg-themes' ) ] = array_merge(
+			$features[ __( 'Layout', 'wporg-themes' ) ],
 			array(
-				'fixed-layout'      => __( 'Fixed Layout' ),
-				'fluid-layout'      => __( 'Fluid Layout' ),
-				'responsive-layout' => __( 'Responsive Layout' ),
+				'fixed-layout'      => __( 'Fixed Layout', 'wporg-themes' ),
+				'fluid-layout'      => __( 'Fluid Layout', 'wporg-themes' ),
+				'responsive-layout' => __( 'Responsive Layout', 'wporg-themes' ),
 			)
 		);
 
-		$features[ __( 'Features' ) ] = array_merge(
-			$features[ __( 'Features' ) ],
+		$features[ __( 'Features', 'wporg-themes' ) ] = array_merge(
+			$features[ __( 'Features', 'wporg-themes' ) ],
 			array(
-				'blavatar' => __( 'Blavatar' ),
+				'blavatar' => __( 'Blavatar', 'wporg-themes' ),
 			)
 		);
 
-		$features[ __( 'Subject' ) ] = array_merge(
-			$features[ __( 'Subject' ) ],
+		$features[ __( 'Subject', 'wporg-themes' ) ] = array_merge(
+			$features[ __( 'Subject', 'wporg-themes' ) ],
 			array(
-				'photoblogging' => __( 'Photoblogging' ),
-				'seasonal'      => __( 'Seasonal' ),
+				'photoblogging' => __( 'Photoblogging', 'wporg-themes' ),
+				'seasonal'      => __( 'Seasonal', 'wporg-themes' ),
 			)
 		);
 	}
 
 	if ( 'layouts' === $subset ) {
-		return $features[ __( 'Layout' ) ];
+		return $features[ __( 'Layout', 'wporg-themes' ) ];
 	} else if ( 'features' === $subset ) {
-		return $features[ __( 'Features' ) ];
+		return $features[ __( 'Features', 'wporg-themes' ) ];
 	} else if ( 'subjects' === $subset ) {
-		return $features[ __( 'Subject' ) ];
+		return $features[ __( 'Subject', 'wporg-themes' ) ];
 	}
-	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 
 	return $features;
 }

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -392,7 +392,7 @@ function get_tag_labels( $tags ) {
 }
 
 /**
- * This is a copy of get_theme_feature_list(), but with the wporg-themes text domain
+ * Get all possible features, using the default textdomain to mirror WP core.
  *
  * @param string $include Optional. Type of list: 'active', 'deprecated' or 'all'. Default 'active'.
  * @param string $subset  Optional. Returns only the selected subset of features.
@@ -402,118 +402,120 @@ function get_tag_labels( $tags ) {
 function wporg_themes_get_feature_list( $include = 'active', $subset = '' ) {
 	$features = array();
 
+	// phpcs:disable WordPress.WP.I18n.MissingArgDomain -- Intentionally uses core textdomain.
 	if ( 'active' === $include || 'all' === $include ) {
 		$features = array(
-			__( 'Layout', 'wporg-themes' )   => array(
-				'grid-layout'   => __( 'Grid layout', 'wporg-themes' ),
-				'one-column'    => __( 'One column', 'wporg-themes' ),
-				'two-columns'   => __( 'Two columns', 'wporg-themes' ),
-				'three-columns' => __( 'Three columns', 'wporg-themes' ),
-				'four-columns'  => __( 'Four columns', 'wporg-themes' ),
-				'left-sidebar'  => __( 'Left sidebar', 'wporg-themes' ),
-				'right-sidebar' => __( 'Right sidebar', 'wporg-themes' ),
-				'wide-blocks'   => __( 'Wide blocks', 'wporg-themes' ),
+			__( 'Layout' )   => array(
+				'grid-layout'   => __( 'Grid layout' ),
+				'one-column'    => __( 'One column' ),
+				'two-columns'   => __( 'Two columns' ),
+				'three-columns' => __( 'Three columns' ),
+				'four-columns'  => __( 'Four columns' ),
+				'left-sidebar'  => __( 'Left sidebar' ),
+				'right-sidebar' => __( 'Right sidebar' ),
+				'wide-blocks'   => __( 'Wide blocks' ),
 			),
-			__( 'Features', 'wporg-themes' ) => array(
-				'accessibility-ready'   => __( 'Accessibility ready', 'wporg-themes' ),
-				'block-patterns'        => __( 'Block editor patterns', 'wporg-themes' ),
-				'block-styles'          => __( 'Block editor styles', 'wporg-themes' ),
-				'full-site-editing'     => __( 'Block themes', 'wporg-themes' ),
-				'buddypress'            => __( 'BuddyPress', 'wporg-themes' ),
-				'custom-background'     => __( 'Custom background', 'wporg-themes' ),
-				'custom-colors'         => __( 'Custom colors', 'wporg-themes' ),
-				'custom-header'         => __( 'Custom header', 'wporg-themes' ),
-				'custom-logo'           => __( 'Custom logo', 'wporg-themes' ),
-				'custom-menu'           => __( 'Custom menu', 'wporg-themes' ),
-				'editor-style'          => __( 'Editor style', 'wporg-themes' ),
-				'featured-image-header' => __( 'Featured image header', 'wporg-themes' ),
-				'featured-images'       => __( 'Featured images', 'wporg-themes' ),
-				'flexible-header'       => __( 'Flexible header', 'wporg-themes' ),
-				'footer-widgets'        => __( 'Footer widgets', 'wporg-themes' ),
-				'front-page-post-form'  => __( 'Front page posting', 'wporg-themes' ),
-				'full-width-template'   => __( 'Full width template', 'wporg-themes' ),
-				'microformats'          => __( 'Microformats', 'wporg-themes' ),
-				'post-formats'          => __( 'Post formats', 'wporg-themes' ),
-				'rtl-language-support'  => __( 'RTL language support', 'wporg-themes' ),
-				'sticky-post'           => __( 'Sticky post', 'wporg-themes' ),
-				'style-variations'      => __( 'Style variations', 'wporg-themes' ),
-				'template-editing'      => __( 'Template editing', 'wporg-themes' ),
-				'theme-options'         => __( 'Theme options', 'wporg-themes' ),
-				'threaded-comments'     => __( 'Threaded comments', 'wporg-themes' ),
-				'translation-ready'     => __( 'Translation ready', 'wporg-themes' ),
+			__( 'Features' ) => array(
+				'accessibility-ready'   => __( 'Accessibility ready' ),
+				'block-patterns'        => __( 'Block editor patterns' ),
+				'block-styles'          => __( 'Block editor styles' ),
+				'full-site-editing'     => __( 'Block themes' ),
+				'buddypress'            => __( 'BuddyPress' ),
+				'custom-background'     => __( 'Custom background' ),
+				'custom-colors'         => __( 'Custom colors' ),
+				'custom-header'         => __( 'Custom header' ),
+				'custom-logo'           => __( 'Custom logo' ),
+				'custom-menu'           => __( 'Custom menu' ),
+				'editor-style'          => __( 'Editor style' ),
+				'featured-image-header' => __( 'Featured image header' ),
+				'featured-images'       => __( 'Featured images' ),
+				'flexible-header'       => __( 'Flexible header' ),
+				'footer-widgets'        => __( 'Footer widgets' ),
+				'front-page-post-form'  => __( 'Front page posting' ),
+				'full-width-template'   => __( 'Full width template' ),
+				'microformats'          => __( 'Microformats' ),
+				'post-formats'          => __( 'Post formats' ),
+				'rtl-language-support'  => __( 'RTL language support' ),
+				'sticky-post'           => __( 'Sticky post' ),
+				'style-variations'      => __( 'Style variations' ),
+				'template-editing'      => __( 'Template editing' ),
+				'theme-options'         => __( 'Theme options' ),
+				'threaded-comments'     => __( 'Threaded comments' ),
+				'translation-ready'     => __( 'Translation ready' ),
 			),
-			__( 'Subject', 'wporg-themes' )  => array(
-				'blog'           => __( 'Blog', 'wporg-themes' ),
-				'e-commerce'     => __( 'E-commerce', 'wporg-themes' ),
-				'education'      => __( 'Education', 'wporg-themes' ),
-				'entertainment'  => __( 'Entertainment', 'wporg-themes' ),
-				'food-and-drink' => __( 'Food & drink', 'wporg-themes' ),
-				'holiday'        => __( 'Holiday', 'wporg-themes' ),
-				'news'           => __( 'News', 'wporg-themes' ),
-				'photography'    => __( 'Photography', 'wporg-themes' ),
-				'portfolio'      => __( 'Portfolio', 'wporg-themes' ),
+			__( 'Subject' )  => array(
+				'blog'           => __( 'Blog' ),
+				'e-commerce'     => __( 'E-commerce' ),
+				'education'      => __( 'Education' ),
+				'entertainment'  => __( 'Entertainment' ),
+				'food-and-drink' => __( 'Food & drink' ),
+				'holiday'        => __( 'Holiday' ),
+				'news'           => __( 'News' ),
+				'photography'    => __( 'Photography' ),
+				'portfolio'      => __( 'Portfolio' ),
 			),
 		);
 	}
 
 	if ( 'deprecated' === $include || 'all' === $include ) {
-		$features[ __( 'Colors', 'wporg-themes' ) ] = array(
-			'black'  => __( 'Black', 'wporg-themes' ),
-			'blue'   => __( 'Blue', 'wporg-themes' ),
-			'brown'  => __( 'Brown', 'wporg-themes' ),
-			'gray'   => __( 'Gray', 'wporg-themes' ),
-			'green'  => __( 'Green', 'wporg-themes' ),
-			'orange' => __( 'Orange', 'wporg-themes' ),
-			'pink'   => __( 'Pink', 'wporg-themes' ),
-			'purple' => __( 'Purple', 'wporg-themes' ),
-			'red'    => __( 'Red', 'wporg-themes' ),
-			'silver' => __( 'Silver', 'wporg-themes' ),
-			'tan'    => __( 'Tan', 'wporg-themes' ),
-			'white'  => __( 'White', 'wporg-themes' ),
-			'yellow' => __( 'Yellow', 'wporg-themes' ),
-			'dark'   => __( 'Dark', 'wporg-themes' ),
-			'light'  => __( 'Light', 'wporg-themes' ),
+		$features[ __( 'Colors' ) ] = array(
+			'black'  => __( 'Black' ),
+			'blue'   => __( 'Blue' ),
+			'brown'  => __( 'Brown' ),
+			'gray'   => __( 'Gray' ),
+			'green'  => __( 'Green' ),
+			'orange' => __( 'Orange' ),
+			'pink'   => __( 'Pink' ),
+			'purple' => __( 'Purple' ),
+			'red'    => __( 'Red' ),
+			'silver' => __( 'Silver' ),
+			'tan'    => __( 'Tan' ),
+			'white'  => __( 'White' ),
+			'yellow' => __( 'Yellow' ),
+			'dark'   => __( 'Dark' ),
+			'light'  => __( 'Light' ),
 		);
 
 		if ( 'deprecated' === $include ) {
 			// Initialize arrays.
-			$features[ __( 'Layout', 'wporg-themes' ) ]   = array();
-			$features[ __( 'Features', 'wporg-themes' ) ] = array();
-			$features[ __( 'Subject', 'wporg-themes' ) ]  = array();
+			$features[ __( 'Layout' ) ]   = array();
+			$features[ __( 'Features' ) ] = array();
+			$features[ __( 'Subject' ) ]  = array();
 		}
 
-		$features[ __( 'Layout', 'wporg-themes' ) ] = array_merge(
-			$features[ __( 'Layout', 'wporg-themes' ) ],
+		$features[ __( 'Layout' ) ] = array_merge(
+			$features[ __( 'Layout' ) ],
 			array(
-				'fixed-layout'      => __( 'Fixed Layout', 'wporg-themes' ),
-				'fluid-layout'      => __( 'Fluid Layout', 'wporg-themes' ),
-				'responsive-layout' => __( 'Responsive Layout', 'wporg-themes' ),
+				'fixed-layout'      => __( 'Fixed Layout' ),
+				'fluid-layout'      => __( 'Fluid Layout' ),
+				'responsive-layout' => __( 'Responsive Layout' ),
 			)
 		);
 
-		$features[ __( 'Features', 'wporg-themes' ) ] = array_merge(
-			$features[ __( 'Features', 'wporg-themes' ) ],
+		$features[ __( 'Features' ) ] = array_merge(
+			$features[ __( 'Features' ) ],
 			array(
-				'blavatar' => __( 'Blavatar', 'wporg-themes' ),
+				'blavatar' => __( 'Blavatar' ),
 			)
 		);
 
-		$features[ __( 'Subject', 'wporg-themes' ) ] = array_merge(
-			$features[ __( 'Subject', 'wporg-themes' ) ],
+		$features[ __( 'Subject' ) ] = array_merge(
+			$features[ __( 'Subject' ) ],
 			array(
-				'photoblogging' => __( 'Photoblogging', 'wporg-themes' ),
-				'seasonal'      => __( 'Seasonal', 'wporg-themes' ),
+				'photoblogging' => __( 'Photoblogging' ),
+				'seasonal'      => __( 'Seasonal' ),
 			)
 		);
 	}
 
 	if ( 'layouts' === $subset ) {
-		return $features[ __( 'Layout', 'wporg-themes' ) ];
+		return $features[ __( 'Layout' ) ];
 	} else if ( 'features' === $subset ) {
-		return $features[ __( 'Features', 'wporg-themes' ) ];
+		return $features[ __( 'Features' ) ];
 	} else if ( 'subjects' === $subset ) {
-		return $features[ __( 'Subject', 'wporg-themes' ) ];
+		return $features[ __( 'Subject' ) ];
 	}
+	// phpcs:enable WordPress.WP.I18n.MissingArgDomain
 
 	return $features;
 }

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -4,6 +4,7 @@ namespace WordPressdotorg\Theme\Theme_Directory_2024;
 
 require_once( __DIR__ . '/inc/block-bindings.php' );
 require_once( __DIR__ . '/inc/block-config.php' );
+require_once( __DIR__ . '/inc/i18n.php' );
 require_once( __DIR__ . '/inc/rest-api.php' );
 
 // Block files

--- a/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
@@ -9,7 +9,6 @@ use WP_Post;
 
 const TRANSLATED_TAXONOMIES = [
 	// Taxonomy => Tax label name.
-	'category' => 'Categories',
 	'post_tag' => 'Tags',
 ];
 

--- a/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
@@ -26,7 +26,7 @@ function get_the_theme( $_post = false ) {
 		$_post = $post;
 	}
 
-	$theme_post = get_post( $post );
+	$theme_post = get_post( $_post );
 	// Not a post, or not a theme post type.
 	if ( ! ( $theme_post instanceof WP_Post ) || 'repopackage' !== $theme_post->post_type ) {
 		return false;

--- a/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Set up some helper API endpoints.
+ */
+
+namespace WordPressdotorg\Theme\Theme_Directory_2024\I18N;
+
+use WP_Post;
+
+const TRANSLATED_TAXONOMIES = [
+	// Taxonomy => Tax label name.
+	'category' => 'Categories',
+	'post_tag' => 'Tags',
+];
+
+add_filter( 'the_content', __NAMESPACE__ . '\translate_the_content', 1 );
+add_filter( 'the_title', __NAMESPACE__ . '\translate_the_title', 1, 2 );
+add_filter( 'single_post_title', __NAMESPACE__ . '\translate_the_title', 1, 2 );
+add_filter( 'get_term', __NAMESPACE__ . '\translate_term' );
+
+/**
+ * Get the current theme, given the global post.
+ */
+function get_the_theme( $_post = false ) {
+	global $post;
+	if ( ! $_post ) {
+		$_post = $post;
+	}
+
+	$theme_post = get_post( $post );
+	// Not a post, or not a theme post type.
+	if ( ! ( $theme_post instanceof WP_Post ) || 'repopackage' !== $theme_post->post_type ) {
+		return false;
+	}
+
+	$theme = wporg_themes_theme_information( $theme_post->post_name );
+	if ( isset( $theme->error ) ) {
+		return false;
+	}
+
+	return $theme;
+}
+
+/**
+ * Replace the content with the theme description (possibly translated).
+ */
+function translate_the_content( $content ) {
+	if ( is_admin() ) {
+		return $content;
+	}
+
+	$theme = get_the_theme();
+	if ( isset( $theme->description ) ) {
+		return $theme->description;
+	}
+
+	return $content;
+}
+
+/**
+ * Replace the title with the theme name (possibly translated), or a translated page title.
+ *
+ * @param string $title   The current title, ignored.
+ * @param int    $post_id The post_id of the page/theme.
+ *
+ * @return string Possibly translated theme or page title.
+ */
+function translate_the_title( $title, $post_id = null ) {
+	if ( is_admin() ) {
+		return $title;
+	}
+
+	$theme = get_the_theme( $post_id );
+	if ( isset( $theme->name ) ) {
+		return $theme->name;
+	}
+
+	$post = get_post( $post_id );
+	if ( $post && 'page' === $post->post_type ) {
+		$title = translate_with_gettext_context( $post->post_title, $post->post_type . ' title', 'wporg-themes' ); // phpcs:ignore
+	}
+
+	return $title;
+}
+
+/**
+ * Translate term names into the current site locale.
+ *
+ * @param WP_Term $term The WP_Term object being loaded.
+ */
+function translate_term( $term ) {
+	// Not get_user_locale(), as we respect the displayed site locale.
+	if ( is_admin() || 'en_US' === get_locale() || ! isset( TRANSLATED_TAXONOMIES[ $term->taxonomy ] ) ) {
+		return $term;
+	}
+
+	$label = TRANSLATED_TAXONOMIES[ $term->taxonomy ];
+	$term->name = strrev( translate_with_gettext_context( html_entity_decode( $term->name ), $label . ' term name', 'wporg-themes' ) ); // phpcs:ignore
+	if ( ! empty( $term->description ) ) {
+		$term->description = esc_html( translate_with_gettext_context( html_entity_decode( $term->description ), $label . ' term description', 'wporg-themes' ) ); // phpcs:ignore
+	}
+
+	return $term;
+}

--- a/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
@@ -94,7 +94,7 @@ function translate_term( $term ) {
 	}
 
 	$label = TRANSLATED_TAXONOMIES[ $term->taxonomy ];
-	$term->name = strrev( translate_with_gettext_context( html_entity_decode( $term->name ), $label . ' term name', 'wporg-themes' ) ); // phpcs:ignore
+	$term->name = esc_html( translate_with_gettext_context( html_entity_decode( $term->name ), $label . ' term name', 'wporg-themes' ) ); // phpcs:ignore
 	if ( ! empty( $term->description ) ) {
 		$term->description = esc_html( translate_with_gettext_context( html_entity_decode( $term->description ), $label . ' term description', 'wporg-themes' ) ); // phpcs:ignore
 	}

--- a/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
@@ -6,11 +6,7 @@
 namespace WordPressdotorg\Theme\Theme_Directory_2024\I18N;
 
 use WP_Post;
-
-const TRANSLATED_TAXONOMIES = [
-	// Taxonomy => Tax label name.
-	'post_tag' => 'Tags',
-];
+use function WordPressdotorg\Theme\Theme_Directory_2024\wporg_themes_get_feature_list;
 
 add_filter( 'the_content', __NAMESPACE__ . '\translate_the_content', 1 );
 add_filter( 'the_title', __NAMESPACE__ . '\translate_the_title', 1, 2 );
@@ -83,20 +79,24 @@ function translate_the_title( $title, $post_id = null ) {
 }
 
 /**
- * Translate term names into the current site locale.
+ * Translate tag names into the current site locale.
+ *
+ * Only tags are visible on the frontend. We can ignore categories,
+ * and `theme_business_model` is never output as terms.
  *
  * @param WP_Term $term The WP_Term object being loaded.
  */
 function translate_term( $term ) {
-	// Not get_user_locale(), as we respect the displayed site locale.
-	if ( is_admin() || 'en_US' === get_locale() || ! isset( TRANSLATED_TAXONOMIES[ $term->taxonomy ] ) ) {
+	if ( is_admin() || 'post_tag' !== $term->taxonomy ) {
 		return $term;
 	}
 
-	$label = TRANSLATED_TAXONOMIES[ $term->taxonomy ];
-	$term->name = esc_html( translate_with_gettext_context( html_entity_decode( $term->name ), $label . ' term name', 'wporg-themes' ) ); // phpcs:ignore
-	if ( ! empty( $term->description ) ) {
-		$term->description = esc_html( translate_with_gettext_context( html_entity_decode( $term->description ), $label . ' term description', 'wporg-themes' ) ); // phpcs:ignore
+	// Get the feature list, collapsed into a one-dimensional array.
+	$features = wporg_themes_get_feature_list( 'all' );
+	$features = array_merge( ...array_values( $features ) );
+
+	if ( isset( $features[ $term->slug ] ) ) {
+		$term->name = $features[ $term->slug ];
 	}
 
 	return $term;


### PR DESCRIPTION
Fixes #74. This uses the theme object content for themes, which should automatically use the localized theme name and description.

Additionally, I've added the in-progress i18n composite action (https://github.com/WordPress/wporg-repo-tools/pull/31), which pulls down term and page titles so that they can be easily imported into GlotPress with the rest of the strings (this is the generated commit https://github.com/WordPress/wporg-theme-directory/commit/4e7830446f5aa21abdec8f7f8f9e9fbc85d5df9f). As this theme is not being parsed yet, this doesn't do anything, but once it's indexed it should expose those items for translation so that, for example, ["Commercially Supported GPL Themes" in the local nav](https://cn.wordpress.org/themes/commercial/) can be translated.

The translation code was pulled from [pattern-translations](https://github.com/WordPress/pattern-directory/blob/4368e75947ed523f64db32086a3da55e0eca4441/public_html/wp-content/plugins/pattern-translations/pattern-translations.php#L78-L118).

### Screenshots

The theme title & description are translated. The "Features" list will be translated once the project is in GlotPress (and translated).

| Before | After |
|--------|-------|
| ![Screen Shot 2024-05-29 at 16 53 48](https://github.com/WordPress/wporg-theme-directory/assets/541093/10eccadc-193a-4f4f-afea-d086bf5535c7) | ![Screen Shot 2024-05-29 at 16 53 35](https://github.com/WordPress/wporg-theme-directory/assets/541093/ba3bf635-f0b3-4775-b09c-670f5d466151) |

### How to test the changes in this Pull Request:

1. Using a sandbox, view a popular theme (more likely it will have translations)
2. The title and content should appear translated

You can also test the page name and term name translations with [Pig Latin](https://wordpress.org/plugins/search/pig-latin/), just disable the `en_US` check in `translate_term`. You'll see some errors about the font_subset though.
