### PR TITLE
Move see all review link under the ratings.

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/inc/block-bindings.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-bindings.php
@@ -78,7 +78,7 @@ function get_meta_block_value( $args, $block ) {
 			return sprintf(
 				'<a href="%s">%s</a>',
 				esc_url( get_support_url( $theme->slug . '/reviews/' ) ),
-				__( 'See all reviews', 'wporg-themes' )
+				__( 'See all', 'wporg-themes' )
 			);
 		case 'support-forum-url':
 			return esc_url( get_support_url( $theme->slug ) );

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-bindings.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-bindings.php
@@ -78,7 +78,7 @@ function get_meta_block_value( $args, $block ) {
 			return sprintf(
 				'<a href="%s">%s</a>',
 				esc_url( get_support_url( $theme->slug . '/reviews/' ) ),
-				__( 'See all', 'wporg-themes' )
+				__( 'See all<span class="screen-reader-text"> reviews</span>', 'wporg-themes' )
 			);
 		case 'support-forum-url':
 			return esc_url( get_support_url( $theme->slug ) );

--- a/source/wp-content/themes/wporg-themes-2024/patterns/single.php
+++ b/source/wp-content/themes/wporg-themes-2024/patterns/single.php
@@ -113,14 +113,14 @@
 
 		<!-- wp:wporg/ratings-bars /-->
 
-		<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--10)">
-			<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"ratings-link"}}}},"className":"wporg-ratings-link"} -->
-			<p class="wporg-ratings-link">See all</p>
-			<!-- /wp:paragraph -->
-
 			<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"submit-review-link"}}}}} -->
 			<p>Add my review</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"ratings-link"}}}},"className":"wporg-ratings-link"} -->
+			<p class="wporg-ratings-link">See all</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-themes-2024/patterns/single.php
+++ b/source/wp-content/themes/wporg-themes-2024/patterns/single.php
@@ -120,7 +120,7 @@
 			<!-- /wp:paragraph -->
 
 			<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"submit-review-link"}}}}} -->
-			<p >Add my review</p>
+			<p>Add my review</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-themes-2024/patterns/single.php
+++ b/source/wp-content/themes/wporg-themes-2024/patterns/single.php
@@ -106,9 +106,6 @@
 			<h2 class="wp-block-heading has-heading-4-font-size"><?php esc_html_e( 'Ratings', 'wporg-themes' ); ?></h2>
 			<!-- /wp:heading -->
 
-			<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"ratings-link"}}}},"className":"wporg-ratings-link"} -->
-			<p class="wporg-ratings-link">See all</p>
-			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->
 
@@ -116,9 +113,17 @@
 
 		<!-- wp:wporg/ratings-bars /-->
 
-		<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}}},"metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"submit-review-link"}}}}} -->
-		<p style="margin-top:var(--wp--preset--spacing--10)">Add my review</p>
-		<!-- /wp:paragraph -->
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|10"},"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--10)">
+			<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"ratings-link"}}}},"className":"wporg-ratings-link"} -->
+			<p class="wporg-ratings-link">See all</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"wporg-themes/meta","args":{"key":"submit-review-link"}}}}} -->
+			<p >Add my review</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
 
 		<!-- wp:heading {"fontSize":"heading-4"} -->
 		<h2 class="wp-block-heading has-heading-4-font-size"><?php esc_html_e( 'Support', 'wporg-themes' ); ?></h2>


### PR DESCRIPTION
I find the "see all reviews" link distracting as it's the only right-aligned link that is next to the title in the sidebar.

In this PR I proposed we move it below the reviews which also seems to make the tabbing more logical where you tab through some reviews to reach the "all reviews" link. I wasn't sure which order makes more sense; "add my review" first or "see all reviews" first. I'm open to suggestions on that.

If this change goes in, I'll update the plugin directory to match.

### Screenshots

| Before | After |
|--------|-------|
| <img width="378" alt="Screenshot 2024-06-05 at 10 51 01 AM" src="https://github.com/WordPress/wporg-theme-directory/assets/1657336/97a65a84-2fb1-4fd5-8d1f-7165cb229068">  | <img width="383" alt="Screenshot 2024-06-05 at 10 50 44 AM" src="https://github.com/WordPress/wporg-theme-directory/assets/1657336/c7031f84-e949-4f81-ada2-f35dad552d69"> |

Note: The "after" screenshot data and star ratings don't match as I copied/pasted DOM parts from the live site since my local environment didn't have the ratings table.
