### PR TITLE
Theme previewer: Update back button to navigate all the way back to the theme details page.

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
@@ -89,6 +89,16 @@ while ( $html->next_tag( [ 'class_name' => 'wp-block-wporg-screenshot-preview' ]
 
 $content = $html->get_updated_html();
 
+// Recreate the processor to grab the back button.
+// See https://developer.wordpress.org/reference/classes/wp_html_tag_processor/#finding-tags
+$html = new WP_HTML_Tag_Processor( $content );
+while ( $html->next_tag( [ 'class_name' => 'wporg-theme-preview__back' ] ) ) {
+	$html->next_tag( 'a' );
+	$html->set_attribute( 'data-wp-on--click', 'wporg/themes/preview::actions.goBack' );
+}
+
+$content = $html->get_updated_html();
+
 $markup = sprintf( $markup, $content, esc_url_raw( $url ) );
 
 ?>

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/view.js
@@ -9,7 +9,7 @@ const { state } = store( 'wporg/themes/preview', {
 			const context = getContext();
 			return context.isLoaded;
 		},
-		pages: 1,
+		initialHistory: window.history.length,
 	},
 	actions: {
 		onLoad() {
@@ -17,9 +17,9 @@ const { state } = store( 'wporg/themes/preview', {
 			context.isLoaded = true;
 		},
 		goBack( event ) {
-			if ( window.history.length > state.pages ) {
+			if ( state.initialHistory > 2 ) {
 				event.preventDefault();
-				window.history.go( state.pages * -1 );
+				window.history.go( state.initialHistory - window.history.length - 1 );
 			}
 		},
 		navigateIframe( event ) {
@@ -53,7 +53,6 @@ const { state } = store( 'wporg/themes/preview', {
 
 				context.url = previewURL;
 				window.history.replaceState( {}, '', permalinkURL );
-				state.pages++;
 			}
 		},
 	},

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/view.js
@@ -3,17 +3,24 @@
  */
 import { getContext, getElement, store } from '@wordpress/interactivity';
 
-store( 'wporg/themes/preview', {
+const { state } = store( 'wporg/themes/preview', {
 	state: {
 		get isLoaded() {
 			const context = getContext();
 			return context.isLoaded;
 		},
+		pages: 1,
 	},
 	actions: {
 		onLoad() {
 			const context = getContext();
 			context.isLoaded = true;
+		},
+		goBack( event ) {
+			if ( window.history.length > state.pages ) {
+				event.preventDefault();
+				window.history.go( state.pages * -1 );
+			}
 		},
 		navigateIframe( event ) {
 			event.preventDefault();
@@ -46,6 +53,7 @@ store( 'wporg/themes/preview', {
 
 				context.url = previewURL;
 				window.history.replaceState( {}, '', permalinkURL );
+				state.pages++;
 			}
 		},
 	},


### PR DESCRIPTION
Fixes #87. In that issue, it was suggested that the variations and patterns not add history entries. Unfortunately, the navigation of the `iframe` causes the entries, so we can't get around that. Instead, I've tried a different method. Now, the code tracks how many variations & patterns you've selected, and then uses that count to go backwards X times so that you're back at the theme details page.

If the previewer was opened in a new window, it realizes the history is too short, and just falls back to a regular link to the details view.

~~Currently, this does not handle navigating inside the iframe, for example if you click a post link, it will throw off the history counter. If this approach sounds good I can look into fixing this.~~

### Screenshots

https://github.com/WordPress/wporg-theme-directory/assets/541093/147ec4f5-36c7-4c3a-9757-96d81d8111c5

### How to test the changes in this Pull Request:

1. View a theme archive
2. Open the previewer (in the same tab)
3. Click around variations and patterns
4. Click the previewer back button, it should take you to the theme details page
5. Click your browser's back button, it should take you back to the theme archive you came from

