### PR TITLE
Add error checking around cached values

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -614,6 +614,11 @@ function get_theme_style_variations( $theme_name ) {
 		// The first decode parses out to JSON, the second parses out to an object.
 		$styles = json_decode( json_decode( wp_remote_retrieve_body( $response ) ) );
 
+		// If the response is not an error but invalid, transform into something that will not error.
+		if ( NULL === $styles ) {
+			$styles = [];
+		}
+
 		set_transient( $cache_key, $styles, HOUR_IN_SECONDS );
 	}
 

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -587,6 +587,11 @@ function get_theme_patterns( $theme_name ) {
 		// The first decode parses out to JSON, the second parses out to an object.
 		$patterns = json_decode( json_decode( wp_remote_retrieve_body( $response ) ) );
 
+		// If the response is not an error but invalid, transform into something that will not error.
+		if ( empty( $patterns ) ) {
+			$patterns = [];
+		}
+
 		set_transient( $cache_key, $patterns, HOUR_IN_SECONDS );
 	}
 
@@ -615,7 +620,7 @@ function get_theme_style_variations( $theme_name ) {
 		$styles = json_decode( json_decode( wp_remote_retrieve_body( $response ) ) );
 
 		// If the response is not an error but invalid, transform into something that will not error.
-		if ( NULL === $styles ) {
+		if ( empty( $styles ) ) {
 			$styles = [];
 		}
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/render.php
@@ -10,7 +10,7 @@ if ( ! $current_post_id ) {
 
 $theme_post = get_post( $block->context['postId'] );
 $styles = get_theme_style_variations( $theme_post->post_name );
-$count = count( $styles );
+$count = $styles ? count( $styles ) : 0;
 
 if ( ! $count ) {
 	return '';


### PR DESCRIPTION
Make sure that the value being cached isn't invalid from `json_decode`.

Avoids any warnings on themes where errors exist.