### PR TITLE
API: Avoid multiple concurrent wp-themes requests

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -570,31 +570,14 @@ function wporg_themes_get_feature_list( $include = 'active', $subset = '' ) {
 /**
  * Get the list of patterns from wp-themes.com API.
  */
-function get_theme_patterns( $theme_name ) {
-	$cache_key = 'wporg-themes-' . $theme_name . '-patterns';
-	$patterns = get_transient( $cache_key );
+function get_theme_patterns( $post ) {
+	if ( is_string( $post ) ) {
+		$post = ( new \WPORG_Themes_Repo_Package( $post ) )->wp_post;
+	}
 
-	if ( false === $patterns ) {
-		// Set a short timeout to avoid hammering the API.
-		set_transient( $cache_key, [], 0.5 * MINUTE_IN_SECONDS );
-
-		$url = 'https://wp-themes.com/' . $theme_name . '/';
-		$url = add_query_arg( 'rest_route', '/wporg-patterns/v1/patterns', $url );
-		$response = wp_remote_get( $url );
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return [];
-		}
-
-		// This is decoded twice because the response is a quoted JSON string.
-		// The first decode parses out to JSON, the second parses out to an object.
-		$patterns = json_decode( json_decode( wp_remote_retrieve_body( $response ) ) );
-
-		// If the response is not an error but invalid, transform into something that will not error.
-		if ( empty( $patterns ) ) {
-			$patterns = [];
-		}
-
-		set_transient( $cache_key, $patterns, HOUR_IN_SECONDS );
+	$patterns = get_post_meta( $post->ID, 'theme_patterns', true );
+	if ( ! is_array( $patterns ) ) {
+		$patterns = update_cached_theme_patterns( $post->ID );
 	}
 
 	return $patterns;
@@ -603,32 +586,91 @@ function get_theme_patterns( $theme_name ) {
 /**
  * Get the list of style variations from wp-themes.com API.
  */
-function get_theme_style_variations( $theme_name ) {
-	$cache_key = 'wporg-themes-' . $theme_name . '-style-variations';
-	$styles = get_transient( $cache_key );
+function get_theme_style_variations( $post ) {
+	if ( is_string( $post ) ) {
+		$post = ( new \WPORG_Themes_Repo_Package( $post ) )->wp_post;
+	}
 
-	if ( false === $styles ) {
-		// Set a short timeout to avoid hammering the API.
-		set_transient( $cache_key, [], 0.5 * MINUTE_IN_SECONDS );
-
-		$url = 'https://wp-themes.com/' . $theme_name . '/';
-		$url = add_query_arg( 'rest_route', '/wporg-styles/v1/variations', $url );
-		$response = wp_remote_get( $url );
-		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return [];
-		}
-
-		// This is decoded twice because the response is a quoted JSON string.
-		// The first decode parses out to JSON, the second parses out to an object.
-		$styles = json_decode( json_decode( wp_remote_retrieve_body( $response ) ) );
-
-		// If the response is not an error but invalid, transform into something that will not error.
-		if ( empty( $styles ) ) {
-			$styles = [];
-		}
-
-		set_transient( $cache_key, $styles, HOUR_IN_SECONDS );
+	$styles = get_post_meta( $post->ID, 'style_variations', true );
+	if ( ! is_array( $styles ) ) {
+		$styles = update_cached_style_variations( $post->ID );
 	}
 
 	return $styles;
 }
+
+/**
+ * Update the cached style variations for a theme.
+ *
+ * @param int $post_id
+ * @return array The style variations.
+ */
+function update_cached_style_variations( $post_id ) {
+	$post = get_post( $post_id );
+
+	// If the postmeta doesn't yet exist, set it to empty for other requests.
+	if ( ! is_array( $post->style_variations ) ) {
+		update_post_meta( $post_id, 'style_variations', [] );
+	}
+
+	// Fetch fresh data.
+	$url = 'https://wp-themes.com/' . $post->post_name . '/';
+	$url = add_query_arg( 'rest_route', '/wporg-styles/v1/variations', $url );
+	$response = wp_remote_get( $url );
+	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		return;
+	}
+
+	// This is decoded twice because the response is a quoted JSON string.
+	// The first decode parses out to JSON, the second parses out to an object.
+	$styles = json_decode( json_decode( wp_remote_retrieve_body( $response ) ) );
+
+	// If the response is not an error but invalid, transform into something that will not error.
+	if ( empty( $styles ) ) {
+		$styles = [];
+	}
+
+	update_post_meta( $post_id, 'style_variations', $styles );
+
+	return $styles;
+}
+add_action( 'publish_repopackage', 'update_cached_style_variations', 100, 1 );
+add_action( 'wporg_themes_update_version_live', 'update_cached_style_variations', 100, 1 );
+
+/**
+ * Update the cached theme patterns for a theme.
+ *
+ * @param int $post_id
+ * @return array The theme patterns.
+ */
+function update_cached_theme_patterns( $post_id ) {
+	$post = get_post( $post_id );
+
+	// If the postmeta doesn't yet exist, set it to empty for other requests.
+	if ( ! is_array( $post->theme_patterns ) ) {
+		update_post_meta( $post_id, 'theme_patterns', [] );
+	}
+
+	// Fetch fresh data.
+	$url = 'https://wp-themes.com/' . $post->post_name . '/';
+	$url = add_query_arg( 'rest_route', '/wporg-styles/v1/patterns', $url );
+	$response = wp_remote_get( $url );
+	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		return;
+	}
+
+	// This is decoded twice because the response is a quoted JSON string.
+	// The first decode parses out to JSON, the second parses out to an object.
+	$patterns = json_decode( json_decode( wp_remote_retrieve_body( $response ) ) );
+
+	// If the response is not an error but invalid, transform into something that will not error.
+	if ( empty( $patterns ) ) {
+		$patterns = [];
+	}
+
+	update_post_meta( $post_id, 'theme_patterns', $styles );
+
+	return $patterns;
+}
+add_action( 'publish_repopackage', 'update_cached_theme_patterns', 100, 1 );
+add_action( 'wporg_themes_update_version_live', 'update_cached_theme_patterns', 100, 1 );

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -571,10 +571,6 @@ function wporg_themes_get_feature_list( $include = 'active', $subset = '' ) {
  * Get the list of patterns from wp-themes.com API.
  */
 function get_theme_patterns( $post ) {
-	if ( is_string( $post ) ) {
-		$post = ( new \WPORG_Themes_Repo_Package( $post ) )->wp_post;
-	}
-
 	$patterns = get_post_meta( $post->ID, 'theme_patterns', true );
 	if ( ! is_array( $patterns ) ) {
 		$patterns = update_cached_theme_patterns( $post->ID );
@@ -587,10 +583,6 @@ function get_theme_patterns( $post ) {
  * Get the list of style variations from wp-themes.com API.
  */
 function get_theme_style_variations( $post ) {
-	if ( is_string( $post ) ) {
-		$post = ( new \WPORG_Themes_Repo_Package( $post ) )->wp_post;
-	}
-
 	$styles = get_post_meta( $post->ID, 'style_variations', true );
 	if ( ! is_array( $styles ) ) {
 		$styles = update_cached_style_variations( $post->ID );

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -575,12 +575,13 @@ function get_theme_patterns( $theme_name ) {
 	$patterns = get_transient( $cache_key );
 
 	if ( false === $patterns ) {
+		// Set a short timeout to avoid hammering the API.
+		set_transient( $cache_key, [], 0.5 * MINUTE_IN_SECONDS );
+
 		$url = 'https://wp-themes.com/' . $theme_name . '/';
 		$url = add_query_arg( 'rest_route', '/wporg-patterns/v1/patterns', $url );
 		$response = wp_remote_get( $url );
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			// Set a short timeout to avoid hammering the API during outages.
-			set_transient( $cache_key, [], 0.5 * MINUTE_IN_SECONDS );
 			return [];
 		}
 
@@ -607,12 +608,13 @@ function get_theme_style_variations( $theme_name ) {
 	$styles = get_transient( $cache_key );
 
 	if ( false === $styles ) {
+		// Set a short timeout to avoid hammering the API.
+		set_transient( $cache_key, [], 0.5 * MINUTE_IN_SECONDS );
+
 		$url = 'https://wp-themes.com/' . $theme_name . '/';
 		$url = add_query_arg( 'rest_route', '/wporg-styles/v1/variations', $url );
 		$response = wp_remote_get( $url );
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			// Set a short timeout to avoid hammering the API during outages.
-			set_transient( $cache_key, [], 0.5 * MINUTE_IN_SECONDS );
 			return [];
 		}
 

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -645,7 +645,7 @@ function update_cached_theme_patterns( $post_id ) {
 
 	// Fetch fresh data.
 	$url = 'https://wp-themes.com/' . $post->post_name . '/';
-	$url = add_query_arg( 'rest_route', '/wporg-styles/v1/patterns', $url );
+	$url = add_query_arg( 'rest_route', '/wporg-patterns/v1/patterns', $url );
 	$response = wp_remote_get( $url );
 	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 		return;
@@ -660,7 +660,7 @@ function update_cached_theme_patterns( $post_id ) {
 		$patterns = [];
 	}
 
-	update_post_meta( $post_id, 'theme_patterns', $styles );
+	update_post_meta( $post_id, 'theme_patterns', $patterns );
 
 	return $patterns;
 }

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/render.php
@@ -13,7 +13,7 @@ $show_all = $attributes['showAll'] ?? false;
 $theme_post = get_post( $block->context['postId'] );
 $theme = wporg_themes_theme_information( $theme_post->post_name );
 
-$patterns = get_theme_patterns( $theme_post->post_name );
+$patterns = get_theme_patterns( $theme_post );
 $pattern_count = $patterns ? count( $patterns ) : 0;
 $initial_count = $show_all ? $pattern_count : 6;
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
@@ -38,7 +38,7 @@ if ( $is_playground ) {
 // Switch to using the pattern URL if a pattern is requested.
 if ( isset( $_REQUEST['pattern_name'] ) ) {
 	$show_pattern = wp_unslash( $_REQUEST['pattern_name'] ); // phpcs:ignore -- exact match to a given string.
-	$patterns = get_theme_patterns( $theme_post->post_name );
+	$patterns = get_theme_patterns( $theme_post );
 	if ( $patterns ) {
 		$matches = wp_list_filter( $patterns, [ 'name' => $show_pattern ] );
 		if ( $matches ) {
@@ -51,7 +51,7 @@ if ( isset( $_REQUEST['pattern_name'] ) ) {
 // Add the style variation to the URL if one is selected.
 if ( isset( $_REQUEST['style_variation'] ) ) {
 	$show_style = wp_unslash( $_REQUEST['style_variation'] ); // phpcs:ignore -- exact match to a given string.
-	$styles = get_theme_style_variations( $theme_post->post_name );
+	$styles = get_theme_style_variations( $theme_post );
 	if ( $styles ) {
 		$matches = wp_list_filter( $styles, [ 'title' => $show_style ] );
 		if ( $matches ) {

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/render.php
@@ -9,7 +9,7 @@ if ( ! $current_post_id ) {
 }
 
 $theme_post = get_post( $block->context['postId'] );
-$styles = get_theme_style_variations( $theme_post->post_name );
+$styles = get_theme_style_variations( $theme_post );
 $count = $styles ? count( $styles ) : 0;
 
 if ( ! $count ) {

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
@@ -55,7 +55,7 @@ function get_style_variation_card( $style ) {
  * Get the full-sized images for each style variation, hide everything but the currently-selected item.
  */
 function get_theme_preview_images( $theme_post ) {
-	$styles = get_theme_style_variations( $theme_post->post_name );
+	$styles = get_theme_style_variations( $theme_post );
 	$output = '';
 
 	foreach ( $styles as $style ) {

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/render.php
@@ -9,7 +9,7 @@ if ( ! $current_post_id ) {
 }
 
 $theme_post = get_post( $block->context['postId'] );
-$styles = get_theme_style_variations( $theme_post->post_name );
+$styles = get_theme_style_variations( $theme_post );
 $count = $styles ? count( $styles ) : 0;
 
 if ( ! $count ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

The code for fetching Patterns and Style variations from wp-themes attempts to avoid issues during outages, but doesn't make any effort to lock the request, to avoid many queries hitting wp-themes.com at the same time when the transient isn't set.

This PR simply sets the short transient before making the HTTP request, ensuring that only a single request is being processed against wp-themes.com at any time.

This could be enhanced in general by..
 - Keying by version, and setting a longer cache time
 - Not calling this at use-time in the theme, but rather, from the `update wp-themes.com deployed theme version` handler (`wporg_themes_update_wpthemescom()`) and caching it against the Theme Post in post_meta.