### PR TITLE
Theme upload: Catch the theme check output, style results

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/src/theme-upload-form/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-upload-form/index.php
@@ -37,7 +37,10 @@ function render( $attributes, $content, $block ) {
 	// Enqueue the notice style so the below markup is styled correctly.
 	wp_enqueue_style( 'wporg-notice-style' );
 
-	$form = do_shortcode( '[wporg-themes-upload]' );
+	// Theme check results are echo'd directly, so catch all output.
+	ob_start();
+	echo do_shortcode( '[wporg-themes-upload]' );
+	$form = ob_get_clean();
 
 	// Replace default HTML with styled block components.
 	$form  = preg_replace(

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-upload-form/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-upload-form/style.scss
@@ -33,4 +33,43 @@
 		}
 	}
 
+	.tc-lead {
+		font-weight: 600;
+	}
+
+	.tc-result {
+		padding-inline-start: 0;
+		list-style: none;
+		font-size: var(--wp--preset--font-size--small);
+
+		li {
+			margin-block-start: calc(var(--wp--preset--spacing--10) / 2);
+			padding: var(--wp--preset--spacing--10);
+			border-inline-start: 3px solid currentColor;
+
+			> :last-child {
+				margin-block-end: 0;
+			}
+		}
+
+		li:has(.tc-required),
+		li:has(.tc-warning) {
+			border-color: var(--wp--preset--color--pomegrade-1);
+			background: var(--wp--preset--color--pomegrade-3);
+		}
+
+		li:has(.tc-recommended),
+		li:has(.tc-info) {
+			border-color: var(--wp--preset--color--light-grey-1);
+			background: var(--wp--preset--color--light-grey-2);
+		}
+
+		// Don't add space between groups of the same level.
+		li:has(.tc-required) + li:has(.tc-required),
+		li:has(.tc-warning) + li:has(.tc-warning),
+		li:has(.tc-recommended) + li:has(.tc-recommended),
+		li:has(.tc-info) + li:has(.tc-info) {
+			margin-block-start: 0;
+		}
+	}
 }


### PR DESCRIPTION
Fixes #153. The Theme Check results are `echo`d directly when run, which now happens when the block is rendered. This change catches that output using output buffering, and styles the theme check results.

### Screenshots

| Before | After - theme failed checks | After - theme passed checks |
|---|--------|-------|
| ![CleanShot 2024-07-11 at 13 05 58@2x](https://github.com/WordPress/wporg-theme-directory/assets/7585600/16ea429b-ef61-408d-a023-7262bd94a5b8) | ![theme-check-fail](https://github.com/user-attachments/assets/d035eef1-3abe-4962-99a4-8d124ef5ae51) | ![theme-check-pass](https://github.com/user-attachments/assets/ded2994c-7ecd-4883-8fcf-5f71fed3213d) |

Note: this does expect a heading change in the theme-directory plugin, so that the "Results of Automated Theme Scanning…" becomes an h2 to match the page's heading hierarchy. 