### PR TITLE
Navigation: Add "Log in" link to local nav

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
@@ -211,7 +211,7 @@ function add_site_navigation_menus( $menus ) {
 	if ( ! is_user_logged_in() ) {
 		$redirect_url = isset( $_SERVER['REQUEST_URI'] ) ? home_url( $_SERVER['REQUEST_URI'] ) : home_url();
 		$menu[] = array(
-			'label' => __( 'Sign in', 'wporg-themes' ),
+			'label' => __( 'Log in', 'wporg-themes' ),
 			'url' => wp_login_url( $redirect_url ),
 		);
 	}

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
@@ -209,9 +209,10 @@ function add_site_navigation_menus( $menus ) {
 		'className' => ( 'favorites' === $current_browse ? 'current-menu-item ' : '' ) . 'has-separator',
 	);
 	if ( ! is_user_logged_in() ) {
+		$redirect_url = isset( $_SERVER['REQUEST_URI'] ) ? home_url( $_SERVER['REQUEST_URI'] ) : home_url();
 		$menu[] = array(
 			'label' => __( 'Sign in', 'wporg-themes' ),
-			'url' => wp_login_url( home_url() ),
+			'url' => wp_login_url( $redirect_url ),
 		);
 	}
 

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
@@ -208,6 +208,12 @@ function add_site_navigation_menus( $menus ) {
 		'url' => '/browse/favorites/',
 		'className' => ( 'favorites' === $current_browse ? 'current-menu-item ' : '' ) . 'has-separator',
 	);
+	if ( ! is_user_logged_in() ) {
+		$menu[] = array(
+			'label' => __( 'Sign in', 'wporg-themes' ),
+			'url' => wp_login_url( home_url() ),
+		);
+	}
 
 	$browse_menu = array(
 		array(

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
@@ -209,7 +209,8 @@ function add_site_navigation_menus( $menus ) {
 		'className' => ( 'favorites' === $current_browse ? 'current-menu-item ' : '' ) . 'has-separator',
 	);
 	if ( ! is_user_logged_in() ) {
-		$redirect_url = isset( $_SERVER['REQUEST_URI'] ) ? home_url( $_SERVER['REQUEST_URI'] ) : home_url();
+		global $wp;
+		$redirect_url = home_url( $wp->request );
 		$menu[] = array(
 			'label' => __( 'Log in', 'wporg-themes' ),
 			'url' => wp_login_url( $redirect_url ),


### PR DESCRIPTION
This updates the Theme Directory to include the "Sign in" link in the local navigation across the site. The link only appears when you're logged out, once logged in, you can manage your account/login status in the admin bar.

I've already deactivated the "Logged Out Admin Bar" plugin on this site, so it won't show until you log in (and then it will show on all sites, see https://github.com/WordPress/wporg-mu-plugins/commit/3b39f5f1d1134b266e68ac966744a584d464279b).

See https://github.com/WordPress/wporg-mu-plugins/issues/647

### Screenshots

| Logged out | Logged in |
|--------|-------|
| ![Screen Shot 2024-09-09 at 16 37 30](https://github.com/user-attachments/assets/8f43690d-d958-427f-8492-08dd5cbf4fed) | ![Screen Shot 2024-09-09 at 17 17 00](https://github.com/user-attachments/assets/a4d77837-931e-4c45-b9a9-c9a8c72a3f92) |

### How to test the changes in this Pull Request:

1. Be logged out
2. There should be a "sign in" link
3. Clicking it and signing in should redirect you back to the page you were just on
4. The "sign in" link should not appear
5. You should see the admin bar
