### PR TITLE
Ratings: Improve star icon accessibility

### DIFF
--- a/source/wp-content/plugins/wporg-ratings/wporg-ratings.php
+++ b/source/wp-content/plugins/wporg-ratings/wporg-ratings.php
@@ -220,7 +220,7 @@ class WPORG_Ratings {
 	 */
 	public static function get_dashicons_stars( $rating = 0 ): string {
 		$title   = sprintf( __( "%d out of 5 stars", 'wporg-forums' ), $rating );
-		$output  = "<div class='wporg-ratings' aria-label='" . esc_attr( $title ) . "' style='color:#ffb900;'>";
+		$output  = '<div class="wporg-ratings" role="img" aria-label="' . esc_attr( $title ) . '" style="color:#ffb900;">';
 		$counter = round( $rating * 2 );
 		for ( $i = 0; $i < 5; $i ++ ) {
 			switch ( $counter ) {

--- a/source/wp-content/plugins/wporg-ratings/wporg-ratings.php
+++ b/source/wp-content/plugins/wporg-ratings/wporg-ratings.php
@@ -220,19 +220,19 @@ class WPORG_Ratings {
 	 */
 	public static function get_dashicons_stars( $rating = 0 ): string {
 		$title   = sprintf( __( "%d out of 5 stars", 'wporg-forums' ), $rating );
-		$output  = "<div class='wporg-ratings' title='" . esc_attr( $title ) . "' style='color:#ffb900;'>";
+		$output  = "<div class='wporg-ratings' aria-label='" . esc_attr( $title ) . "' style='color:#ffb900;'>";
 		$counter = round( $rating * 2 );
 		for ( $i = 0; $i < 5; $i ++ ) {
 			switch ( $counter ) {
 				case 0 :
-					$output .= '<span class="dashicons dashicons-star-empty"></span>';
+					$output .= '<span class="dashicons dashicons-star-empty" aria-hidden="true"></span>';
 					break;
 				case 1 :
-					$output .= '<span class="dashicons dashicons-star-half"></span>';
+					$output .= '<span class="dashicons dashicons-star-half" aria-hidden="true"></span>';
 					$counter --;
 					break;
 				default :
-					$output  .= '<span class="dashicons dashicons-star-filled"></span>';
+					$output  .= '<span class="dashicons dashicons-star-filled" aria-hidden="true"></span>';
 					$counter -= 2;
 					break;
 			}


### PR DESCRIPTION
Use aria-label instead of title on the ratings container so the rating text is exposed to screen readers, and mark the decorative dashicons stars as aria-hidden to avoid redundant announcements.

Fixes https://meta.trac.wordpress.org/ticket/8276

### How to test the changes in this Pull Request:

This PR should fix the issue, but I'm not sure how to test it locally.