### PR TITLE
Patterns: Hide "Show all patterns" button after all patterns are shown

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/src/utils/listbox.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/utils/listbox.js
@@ -11,9 +11,9 @@ class wporgListbox {
 		this.selected = state.initialSelected >= 0 ? state.initialSelected : null;
 		this.current = null;
 
-		const button = container.querySelector( 'button' );
-		if ( button ) {
-			button.addEventListener( 'click', this.showAll.bind( this ) );
+		this.button = container.querySelector( 'button' );
+		if ( this.button ) {
+			this.button.addEventListener( 'click', this.showAll.bind( this ) );
 		}
 
 		const listbox = container.querySelector( '[role="listbox"]' );
@@ -98,6 +98,14 @@ class wporgListbox {
 	showAll() {
 		this.state.hideOverflow = false;
 		this.updateRender();
+
+		// Remove the button now that every item is visible, so it can't be
+		// clicked again (which would scroll focus back to the top of the list).
+		if ( this.button ) {
+			const wrapper = this.button.closest( '.wp-block-button' ) || this.button;
+			wrapper.remove();
+			this.button = null;
+		}
 
 		// Trigger the custom "show" event on each image.
 		this.container.querySelectorAll( '.wp-block-wporg-screenshot-preview' ).forEach( ( element ) => {


### PR DESCRIPTION
## Summary

Fixes [meta.trac #8347](https://meta.trac.wordpress.org/ticket/8347).

The "Show all patterns" button on theme pages (e.g. [Twenty Twenty-Five](https://wordpress.org/themes/twentytwentyfive/)) stayed visible after all patterns were displayed. Clicking it again re-ran `showAll()`, which refocused the listbox and scrolled the user back to the top of the pattern list.

## Root cause

`wporgListbox.showAll()` set `hideOverflow = false` and re-rendered to reveal the remaining patterns, but never removed the button. The existing comment in `showAll()` even referred to "the now-removed button" when moving focus — describing intended behavior that was never actually implemented.

## Fix

`showAll()` now removes the button (and its `.wp-block-button` wrapper, so no empty gap/margin is left) once every item is visible, and clears the internal reference. With the button gone it can no longer be clicked, so the scroll-to-top regression is eliminated. Focus still moves from the (removed) button to the listbox as before.

The listbox utility is shared with the style-variations block, which has no show-all button (`this.button` is `null` there), so that block is unaffected.

## Testing

Verified with an isolated jsdom harness loading the actual `listbox.js`:

- Before click: 6 patterns visible, 2 overflow items hidden, button present.
- After click: all 8 visible, button and wrapper removed, internal reference cleared → re-click impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWgtGpLp18ZiPxxKjmaZTc