### PR TITLE
Tools: Fix build by removing deleted wporg-themes package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Setup
               uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: i18n
         uses: WordPress/wporg-repo-tools/.github/actions/i18n@trunk

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -23,7 +23,6 @@
 	"themes": [
 		"./source/wp-content/themes/wporg",
 		"./source/wp-content/themes/wporg-parent-2021",
-		"./source/wp-content/themes/wporg-themes",
 		"./source/wp-content/themes/wporg-themes-2024"
 	],
 	"mappings": {

--- a/composer.json
+++ b/composer.json
@@ -77,16 +77,6 @@
 						"url": "https://meta.svn.wordpress.org/sites/",
 						"reference": "trunk/wordpress.org/public_html/wp-content/themes/pub/wporg/"
 					}
-				},
-				{
-					"name": "wordpress-meta/wporg-themes",
-					"type": "wordpress-theme",
-					"version": "1",
-					"source": {
-						"type": "svn",
-						"url": "https://meta.svn.wordpress.org/sites/",
-						"reference": "trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/"
-					}
 				}
 			]
 		}
@@ -100,7 +90,6 @@
 		"wordpress-meta/pub": "1",
 		"wordpress-meta/theme-directory": "1",
 		"wordpress-meta/wporg": "1",
-		"wordpress-meta/wporg-themes": "1",
 		"wp-coding-standards/wpcs": "2.*",
 		"wp-phpunit/wp-phpunit": "^5.4",
 		"wpackagist-plugin/chart-card": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "501fbd35326f6f900baaa74534648337",
+    "content-hash": "eb78d8b9c6eb48e6786fd035686976e0",
     "packages": [],
     "packages-dev": [
         {
@@ -2393,16 +2393,6 @@
             "type": "wordpress-theme"
         },
         {
-            "name": "wordpress-meta/wporg-themes",
-            "version": "1",
-            "source": {
-                "type": "svn",
-                "url": "https://meta.svn.wordpress.org/sites/",
-                "reference": "trunk/wordpress.org/public_html/wp-content/themes/pub/wporg-themes/"
-            },
-            "type": "wordpress-theme"
-        },
-        {
             "name": "wp-coding-standards/wpcs",
             "version": "2.3.0",
             "source": {
@@ -2685,16 +2675,16 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "wporg/wporg-repo-tools": 20,
         "wporg/wporg-mu-plugins": 20,
-        "wporg/wporg-parent-2021": 20
+        "wporg/wporg-parent-2021": 20,
+        "wporg/wporg-repo-tools": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## What

The `build` workflow has been failing (e.g. [run #29355734480](https://github.com/WordPress/wporg-theme-directory/actions/runs/29355734480/job/87162770530)) at the `composer install` step.

## Why

`composer.json` defined a `wordpress-meta/wporg-themes` package pointing at:

```
meta.svn.wordpress.org/.../wp-content/themes/pub/wporg-themes/
```

That path was **deleted upstream in r14680** (dd32, 2026-03-09, _"Remove unused themes; These have been replaced by redesigned versions…"_) — the old classic theme was superseded by this repo's own `wporg-themes-2024` block theme.

Because these are SVN `source` packages, `composer install` re-hits SVN on every run, so the dead URL failed the whole install:

```
wordpress-meta/wporg-themes could not be downloaded, svn: E170000:
URL '.../themes/pub/wporg-themes' doesn't exist
```

The setup action's `composer install || composer update wporg/*` fallback then failed a second time on an unrelated constraint (upstream `wporg/wporg-repo-tools` now requires PHP ^8.4), which is what surfaced as the final `exit code 2`.

## Changes

- Remove the obsolete `wordpress-meta/wporg-themes` package from `composer.json` (`repositories` + `require-dev`) and `composer.lock`.
- Remove its `.wp-env.json` theme mount.
- Bump `actions/checkout` `v3.5.3` → `v7.0.0` in both workflows to clear the Node 20 deprecation warning.

The sibling `wordpress-meta/wporg` package (the shared wordpress.org site-frame theme) is still live upstream and stays. `wporg/wporg-repo-tools` remains pinned to its current locked commit, so **no other dependencies change** — the lock diff is a single package removal.

Verified locally: `composer validate` passes and `composer install` resolves cleanly from the lock (no update fallback, no PHP-version conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)