### PR TITLE
Blocks: Escape attribute values built from theme API data

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/src/child-theme-notice/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/child-theme-notice/index.php
@@ -54,7 +54,7 @@ function render( $attributes, $content, $block ) {
 		__( 'This is a child theme of %s.', 'wporg-themes' ),
 		sprintf(
 			'<a href="%1$s">%2$s</a>',
-			home_url( $theme->parent['slug'] . '/' ),
+			esc_url( home_url( $theme->parent['slug'] . '/' ) ),
 			esc_html( $theme->parent['name'] )
 		)
 	);

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/index.php
@@ -48,7 +48,7 @@ function get_pattern_preview_block( $pattern, $is_overflow = false, $is_selected
 	return sprintf(
 		'<li role="option" id="%1$s" data-pattern_name="%2$s" %3$s>%4$s</li>',
 		$instance_id,
-		$pattern->name,
+		esc_attr( $pattern->name ),
 		$extra_attrs,
 		$image_markup
 	);

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/index.php
@@ -44,7 +44,7 @@ function get_style_variation_card( $style, $is_selected = false ) {
 	return sprintf(
 		'<li role="option" id="%1$s" data-style_variation="%2$s" %3$s>%4$s</li>',
 		$instance_id,
-		$style->title,
+		esc_attr( $style->title ),
 		$extra_attrs,
 		$block_markup
 	);

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
@@ -73,7 +73,9 @@ function get_theme_preview_images( $theme_post ) {
 			$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', wp_json_encode( $args ) ) );
 		}
 
-		$output .= '<div data-wp-bind--hidden="state.isHidden" data-wp-context=\'{"style":"' . strtolower( $style->title ) . '"}\'>';
+		$context = wp_json_encode( array( 'style' => strtolower( $style->title ) ) );
+
+		$output .= '<div data-wp-bind--hidden="state.isHidden" data-wp-context="' . esc_attr( $context ) . '">';
 		$output .= $block_markup;
 		$output .= '</div>';
 	}


### PR DESCRIPTION
Style variation titles and pattern names come from the wp-themes.com API and are interpolated into block markup as attribute values. This routes them through `esc_attr()`, and builds the style variation Interactivity API context with `wp_json_encode()` instead of hand-assembled JSON, matching how `render.php` already does it.

Also adds a missing `esc_url()` on the child theme notice link for consistency.

Verified locally against wp-env with live API data — style variation and pattern output renders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsVZtJxpiEuLF1xdmbqM4M