### PR TITLE
Ratings: Stop escaping the checked() markup fragment

### DIFF
--- a/source/wp-content/plugins/wporg-ratings/wporg-ratings.php
+++ b/source/wp-content/plugins/wporg-ratings/wporg-ratings.php
@@ -280,7 +280,7 @@ class WPORG_Ratings {
 				$checked = checked( $i, $rating, false );
 
 				$output .= "<label for='rating_" . esc_attr( $i ) . "'>";
-				$output .= "<input class='hidden' id='rating_" . esc_attr( $i ) . "' type='radio' name='rating' " . esc_attr( $checked ) . " value='" . esc_attr( $i ) . "'>";
+				$output .= "<input class='hidden' id='rating_" . esc_attr( $i ) . "' type='radio' name='rating'" . $checked . " value='" . esc_attr( $i ) . "'>";
 				$output .= "<span class='dashicons dashicons-star-empty " . esc_attr( $class ) . "' style='color:#ffb900 !important;' title='" . esc_attr( $text ) . "'></span>";
 				$output .= "<span class='screen-reader-text'>" . esc_html( $text ) . "</span>";
 				$output .= "</label>";


### PR DESCRIPTION
`checked()` returns a ready-made attribute fragment (` checked='checked'`), not a data value, so wrapping it in `esc_attr()` encoded the quotes and emitted:

```html
<input ... name='rating' checked=&#039;checked&#039; value='1'>
```

Browsers parse that unquoted value and still treat the boolean attribute as set, so the star rating control worked — the markup was just malformed. This drops the `esc_attr()` call.

Verified with `WP_HTML_Tag_Processor`: the selected input now renders `checked='checked'`, and unselected inputs have no `checked` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsVZtJxpiEuLF1xdmbqM4M