### PR TITLE
Tools: Fix coding standards violations and lint PHP in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,13 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+            - name: Cache Composer downloads
+              uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+              with:
+                path: ~/.cache/composer
+                key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+                restore-keys: ${{ runner.os }}-composer-
+
             - name: Setup
               # Installs PHP and Composer, and generates phpcs.xml.dist via `npm run setup:tools`.
               # The theme build is not needed to lint PHP.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+    pull_request:
+    push:
+        branches:
+            - trunk
+    # Enable manually running action if necessary.
+    workflow_dispatch:
+
+jobs:
+    php:
+        name: PHP coding standards
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+            - name: Setup
+              # Installs PHP and Composer, and generates phpcs.xml.dist via `npm run setup:tools`.
+              # The theme build is not needed to lint PHP.
+              uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk
+              with:
+                token: ${{ secrets.GITHUB_TOKEN }}
+                packageManager: npm
+                skip-build: 'true'
+
+            - name: Run PHPCS
+              run: npm run lint:php

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
 		}
 	],
 	"require-dev": {
-		"composer/installers": "~1.0",
+		"composer/installers": "^2.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"wordpress-meta/pub": "1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b8550ceabdd8064572cb6b406fa9230",
+    "content-hash": "a76cb50edcd081ec353a0e99e32c5993",
     "packages": [],
     "packages-dev": [
         {
@@ -66,39 +66,37 @@
         },
         {
             "name": "composer/installers",
-            "version": "v1.12.0",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19"
+                "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/d20a64ed3c94748397ff5973488761b22f6d3f19",
-                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19",
+                "url": "https://api.github.com/repos/composer/installers/zipball/12fb2dfe5e16183de69e784a7b84046c43d97e8e",
+                "reference": "12fb2dfe5e16183de69e784a7b84046c43d97e8e",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0"
-            },
-            "replace": {
-                "roundcube/plugin-installer": "*",
-                "shama/baton": "*"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "composer/composer": "1.6.* || ^2.0",
-                "composer/semver": "^1 || ^3",
-                "phpstan/phpstan": "^0.12.55",
-                "phpstan/phpstan-phpunit": "^0.12.16",
-                "symfony/phpunit-bridge": "^4.2 || ^5",
-                "symfony/process": "^2.3"
+                "composer/composer": "^1.10.27 || ^2.7",
+                "composer/semver": "^1.7.2 || ^3.4.0",
+                "phpstan/phpstan": "^1.11",
+                "phpstan/phpstan-phpunit": "^1",
+                "symfony/phpunit-bridge": "^7.1.1",
+                "symfony/process": "^5 || ^6 || ^7"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "Composer\\Installers\\Plugin",
                 "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
+                    "dev-main": "2.x-dev"
+                },
+                "plugin-modifies-install-path": true
             },
             "autoload": {
                 "psr-4": {
@@ -119,7 +117,6 @@
             "description": "A multi-framework Composer library installer",
             "homepage": "https://composer.github.io/installers/",
             "keywords": [
-                "Craft",
                 "Dolibarr",
                 "Eliasis",
                 "Hurad",
@@ -140,7 +137,6 @@
                 "Whmcs",
                 "WolfCMS",
                 "agl",
-                "aimeos",
                 "annotatecms",
                 "attogram",
                 "bitrix",
@@ -149,6 +145,7 @@
                 "cockpit",
                 "codeigniter",
                 "concrete5",
+                "concreteCMS",
                 "croogo",
                 "dokuwiki",
                 "drupal",
@@ -159,7 +156,6 @@
                 "grav",
                 "installer",
                 "itop",
-                "joomla",
                 "known",
                 "kohana",
                 "laravel",
@@ -168,6 +164,7 @@
                 "magento",
                 "majima",
                 "mako",
+                "matomo",
                 "mediawiki",
                 "miaoxing",
                 "modulework",
@@ -187,9 +184,7 @@
                 "silverstripe",
                 "sydes",
                 "sylius",
-                "symfony",
                 "tastyigniter",
-                "typo3",
                 "wordpress",
                 "yawik",
                 "zend",
@@ -197,7 +192,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v1.12.0"
+                "source": "https://github.com/composer/installers/tree/v2.3.0"
             },
             "funding": [
                 {
@@ -213,7 +208,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-13T08:19:44+00:00"
+            "time": "2024-06-24T20:46:46+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -4,26 +4,26 @@ namespace WordPressdotorg\Theme\Theme_Directory_2024;
 
 const THEME_POST_TYPE = 'repopackage';
 
-require_once( __DIR__ . '/inc/block-bindings.php' );
-require_once( __DIR__ . '/inc/block-config.php' );
-require_once( __DIR__ . '/inc/embed.php' );
-require_once( __DIR__ . '/inc/i18n.php' );
-require_once( __DIR__ . '/inc/seo-social-meta.php' );
+require_once __DIR__ . '/inc/block-bindings.php';
+require_once __DIR__ . '/inc/block-config.php';
+require_once __DIR__ . '/inc/embed.php';
+require_once __DIR__ . '/inc/i18n.php';
+require_once __DIR__ . '/inc/seo-social-meta.php';
 
 // Block files
-require_once( __DIR__ . '/src/business-model-notice/index.php' );
-require_once( __DIR__ . '/src/child-theme-notice/index.php' );
-require_once( __DIR__ . '/src/meta-list/index.php' );
-require_once( __DIR__ . '/src/theme-available-translations/index.php' );
-require_once( __DIR__ . '/src/theme-downloads/index.php' );
-require_once( __DIR__ . '/src/theme-patterns/index.php' );
-require_once( __DIR__ . '/src/theme-previewer/index.php' );
-require_once( __DIR__ . '/src/theme-previewer-settings/index.php' );
-require_once( __DIR__ . '/src/theme-settings/index.php' );
-require_once( __DIR__ . '/src/theme-status-notice/index.php' );
-require_once( __DIR__ . '/src/theme-style-variations/index.php' );
-require_once( __DIR__ . '/src/theme-style-variations-items/index.php' );
-require_once( __DIR__ . '/src/theme-upload-form/index.php' );
+require_once __DIR__ . '/src/business-model-notice/index.php';
+require_once __DIR__ . '/src/child-theme-notice/index.php';
+require_once __DIR__ . '/src/meta-list/index.php';
+require_once __DIR__ . '/src/theme-available-translations/index.php';
+require_once __DIR__ . '/src/theme-downloads/index.php';
+require_once __DIR__ . '/src/theme-patterns/index.php';
+require_once __DIR__ . '/src/theme-previewer/index.php';
+require_once __DIR__ . '/src/theme-previewer-settings/index.php';
+require_once __DIR__ . '/src/theme-settings/index.php';
+require_once __DIR__ . '/src/theme-status-notice/index.php';
+require_once __DIR__ . '/src/theme-style-variations/index.php';
+require_once __DIR__ . '/src/theme-style-variations-items/index.php';
+require_once __DIR__ . '/src/theme-upload-form/index.php';
 
 /**
  * Actions and filters.
@@ -53,7 +53,7 @@ remove_filter( 'post_thumbnail_html', 'wporg_themes_post_thumbnail_html', 10, 5 
 // Hide admin bar on preview pages.
 add_filter(
 	'show_admin_bar',
-	function( $should_show ) {
+	function ( $should_show ) {
 		global $wp_query;
 
 		if ( isset( $wp_query->query_vars['view'] ) ) {
@@ -67,7 +67,7 @@ add_filter(
 
 add_action(
 	'init',
-	function() {
+	function () {
 		// Don't swap author link with w.org profile link.
 		remove_all_filters( 'author_link' );
 
@@ -429,7 +429,7 @@ function get_query_tags() {
 function get_tag_labels( $tags ) {
 	$features = wporg_themes_get_feature_list( 'active' );
 	$labels = array_map(
-		function( $tag ) use ( $features ) {
+		function ( $tag ) use ( $features ) {
 			foreach ( $features as $list ) {
 				if ( isset( $list[ $tag ] ) ) {
 					return $list[ $tag ];

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
@@ -267,7 +267,7 @@ function get_favorite_settings( $settings, $post_id ) {
 
 	return array(
 		'is_favorite' => wporg_themes_is_favourited( $theme_post->slug ),
-		'add_callback' => function( $post_id ) {
+		'add_callback' => function ( $post_id ) {
 			$theme_post = get_theme_information( $post_id );
 			if ( ! $theme_post ) {
 				return new \WP_Error( 'theme-not-found', 'Theme not found.' );
@@ -275,7 +275,7 @@ function get_favorite_settings( $settings, $post_id ) {
 
 			return wporg_themes_add_favorite( $theme_post->slug );
 		},
-		'delete_callback' => function( $post_id ) {
+		'delete_callback' => function ( $post_id ) {
 			$theme_post = get_theme_information( $post_id );
 			if ( ! $theme_post ) {
 				return new \WP_Error( 'theme-not-found', 'Theme not found.' );

--- a/source/wp-content/themes/wporg-themes-2024/inc/embed.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/embed.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * Customizations for oEmbed output.
+ */
 
 namespace WordPressdotorg\Theme\Theme_Directory_2024\Embed;
 

--- a/source/wp-content/themes/wporg-themes-2024/inc/seo-social-meta.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/seo-social-meta.php
@@ -5,8 +5,8 @@
 
 namespace WordPressdotorg\Theme\Theme_Directory_2024\SEO_Social_Meta;
 
-use const WordPressdotorg\Theme\Theme_Directory_2024\THEME_POST_TYPE;
 use function WordPressdotorg\Theme\Theme_Directory_2024\{ get_query_tags, get_tag_labels, get_theme_information };
+use const WordPressdotorg\Theme\Theme_Directory_2024\THEME_POST_TYPE;
 
 add_filter( 'document_title_parts', __NAMESPACE__ . '\set_document_title' );
 add_filter( 'document_title_separator', __NAMESPACE__ . '\document_title_separator' );

--- a/source/wp-content/themes/wporg-themes-2024/src/meta-list/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/meta-list/index.php
@@ -69,7 +69,7 @@ function render( $attributes, $content, $block ) {
 	if ( isset( $attributes['meta'] ) ) {
 		$meta_fields = array_filter(
 			$meta_fields,
-			function( $field ) use ( $attributes ) {
+			function ( $field ) use ( $attributes ) {
 				return in_array( $field['key'], $attributes['meta'] );
 			}
 		);

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer-settings/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer-settings/render.php
@@ -37,7 +37,7 @@ $blueprint = [
 			'username' => 'admin',
 			'password' => 'password',
 		],
-	]
+	],
 ];
 
 if ( $theme_post->preview_blueprint ) {
@@ -64,11 +64,11 @@ $encoded_state = wp_json_encode( $init_state );
 	data-wp-interactive="wporg/themes/theme-previewer-settings"
 	data-wp-context="<?php echo esc_attr( $encoded_state ); ?>"
 >
-	<h2><?php _e( 'Theme Preview options', 'wporg-themes' ) ?></h2>
+	<h2><?php esc_html_e( 'Theme Preview options', 'wporg-themes' ); ?></h2>
 	<p class="wporg-theme-settings__description">
 		This is a work in progress, and not currently fully supported.<br>
 		Provide a Playground Blueprint to of your theme to be used for previews.<br>
-		The <a href="https://playground.wordpress.net/builder/builder.html#<?php echo urlencode( $blueprint ) ?>">Blueprint Builder</a> can be used to validate your JSON.
+		The <a href="https://playground.wordpress.net/builder/builder.html#<?php echo urlencode( $blueprint ); ?>">Blueprint Builder</a> can be used to validate your JSON.
 	</p>
 	<form data-wp-on--submit="actions.onSubmit" method="POST">
 		<div class="wporg-theme-settings__blueprint-field">

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/iframe/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/iframe/render.php
@@ -7,7 +7,7 @@ if ( ! $current_post_id ) {
 	return;
 }
 
-$is_playground = (bool) ( $_REQUEST['playground-preview'] ?? false );
+$is_playground = ! empty( $_REQUEST['playground-preview'] );
 
 $theme_post = get_post( $block->context['postId'] );
 $theme = wporg_themes_theme_information( $theme_post->post_name );

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
@@ -10,7 +10,7 @@ if ( ! $current_post_id ) {
 // Manually enqueue this script, so that it's available for the interactivity view script.
 wp_enqueue_script( 'wp-a11y' );
 
-$is_playground = (bool) ( $_REQUEST['playground-preview'] ?? false );
+$is_playground = ! empty( $_REQUEST['playground-preview'] );
 
 $theme_post = get_post( $block->context['postId'] );
 $theme = wporg_themes_theme_information( $theme_post->post_name );


### PR DESCRIPTION
Follow-up to #170 (merged) — originally stacked on it, now rebased onto `trunk`.

Once phpcs ran again it reported **34 violations** that had been invisible for as long as it was crashing.

### 27 fixed mechanically with phpcbf

Redundant brackets on `require_once`, function declaration spacing, one missing trailing comma, two missing semicolons in embedded PHP. No behaviour change.

### 7 needed judgement

- **`_e()` → `esc_html_e()`** on the previewer settings heading. A genuine unescaped output, though the string is a hardcoded translation.
- **`$is_playground`** now uses `! empty( $_REQUEST['playground-preview'] )` instead of `(bool) ( $_REQUEST[...] ?? false )`. phpcs could not see the cast through `??` as sanitizing. Behaviour is identical for missing, empty, `"0"` and truthy values — verified by loading the preview page with and without the parameter, which still branches.
- **File header ordering** — a file docblock on `embed.php`, and `use function` before `use const` in `seo-social-meta.php`, per PSR12.

### CI

New `Lint` workflow on pull requests and pushes to trunk. It reuses `WordPress/wporg-repo-tools/.github/actions/setup`, which installs svn and PHP 8.4 and runs `setup:tools` to generate `phpcs.xml.dist` — the step that has to happen before phpcs can resolve its ruleset. `skip-build: true` since linting PHP does not need built theme assets.

The Composer download cache is restored between runs (keyed on `composer.lock`) — the install dominated the job at ~105s of a ~2min run, and repo-tools only caches npm, not Composer.

Also updates `composer/installers` to v2: v1.x predates PHP 8.4 and printed implicit-nullable deprecation notices on every Composer command in the job log.

Scope note: `npm run lint:php` only covers `wporg-themes-2024`. The `wporg-ratings` plugin is also tracked here and is **not** linted — it has at least one PHP 8.4 deprecation (`set_rating()` declares an optional parameter before required ones). Left out so this PR does not grow further.

The remaining deprecation notice in CI (`text_domain` comma-separated property) comes from the generated `phpcs.xml.dist` and needs an upstream fix in wporg-repo-tools' config template.

### Verification

- `npm run lint:php` exits 0, zero violations — the workflow itself passes on this PR
- `php -l` clean on every changed file
- Site, theme, preview and `?playground-preview=1` pages all return 200 on PHP 8.4 with no fatals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsVZtJxpiEuLF1xdmbqM4M
