### PR TITLE
Disable style variation carousel arrows when there is no more content

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/style.scss
@@ -20,6 +20,17 @@
 	.wporg-theme-style-variations__buttons {
 		display: flex;
 
+		/*
+		 * Disabled arrows ignore pointer events, so rapid clicks land on this
+		 * container; without this they would start a text selection.
+		 */
+		user-select: none;
+
+		// The flex display above would otherwise override the hidden attribute.
+		&[hidden] {
+			display: none;
+		}
+
 		.wp-block-button__link {
 			--wp--custom--button--spacing--padding--top: 6px !important;
 			--wp--custom--button--spacing--padding--bottom: 6px !important;
@@ -36,6 +47,11 @@
 			border-left: none;
 			border-top-left-radius: 0;
 			border-bottom-left-radius: 0;
+
+			&:focus {
+				// The focus style trades the 1px border for padding, but this button has no left border to trade.
+				padding-left: var(--wp--custom--button--spacing--padding--left) !important;
+			}
 		}
 
 		svg {
@@ -48,9 +64,7 @@
 		}
 
 		[aria-disabled="true"] {
-			&:hover {
-				--wp--custom--button--outline--hover--color--background: transparent !important;
-			}
+			pointer-events: none;
 
 			svg {
 				fill: var(--wp--preset--color--light-grey-1) !important;

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/view.js
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/view.js
@@ -6,6 +6,13 @@ import { getContext, getElement, store } from '@wordpress/interactivity';
 const OFFSET_WIDTH = 220;
 
 /**
+ * Tolerance in pixels when comparing scroll positions. On zoomed or high-DPI
+ * displays `scrollLeft` can be fractional and never exactly reach the
+ * calculated overflow, which would leave the arrows enabled at the ends.
+ */
+const SCROLL_TOLERANCE = 1;
+
+/**
  * Get the "row" element starting with any block child element.
  *
  * @param {Element} ref
@@ -18,25 +25,23 @@ function getRowElement( ref ) {
 	return element;
 }
 
-// Note about RTL: Browsers scroll "left" into the negative when on RTL, so the
-// logic for when we "canNext"/"canPrevious" are swapped, as are the offsets
-// triggered when clicking the arrow buttons.
+/*
+ * Note about RTL: Browsers scroll "left" into the negative when on RTL, so the
+ * `scrolled` getter normalizes the sign for the "canNext"/"canPrevious"
+ * checks; the offsets triggered when clicking the arrow buttons are swapped.
+ */
 
 const { state } = store( 'wporg/themes/style-variations', {
 	state: {
-		get canPrevious() {
+		get scrolled() {
 			const { isRTL } = getContext();
-			if ( isRTL ) {
-				return state.position < 0;
-			}
-			return state.position > 0;
+			return isRTL ? -state.position : state.position;
+		},
+		get canPrevious() {
+			return state.scrolled > SCROLL_TOLERANCE;
 		},
 		get canNext() {
-			const { isRTL } = getContext();
-			if ( isRTL ) {
-				return state.position >= state.overflow * -1;
-			}
-			return state.position < state.overflow;
+			return state.scrolled < state.overflow - SCROLL_TOLERANCE;
 		},
 		get hasOverscroll() {
 			return state.canNext || state.canPrevious;
@@ -54,23 +59,18 @@ const { state } = store( 'wporg/themes/style-variations', {
 		init() {
 			const element = getRowElement( getElement().ref );
 			state.position = element.scrollLeft;
-			if ( ! element.children.length ) {
-				return;
-			}
-
-			const elStyle = window.getComputedStyle( element );
-			const width = parseInt( elStyle.getPropertyValue( '--wporg-theme-style-variations--size' ), 10 );
-			const gap = parseInt( elStyle.getPropertyValue( 'gap' ), 10 );
-			const fullWidth = element.children.length * width + ( element.children.length - 1 ) * gap;
 
 			// How much extra scroll overflow do we have?
-			state.overflow = fullWidth - element.clientWidth;
+			state.overflow = element.scrollWidth - element.clientWidth;
 		},
 		handleScroll() {
 			const element = getRowElement( getElement().ref );
 			state.position = element.scrollLeft;
 		},
 		handlePrevious() {
+			if ( ! state.canPrevious ) {
+				return;
+			}
 			const { isRTL } = getContext();
 			const element = getRowElement( getElement().ref );
 			const position = isRTL ? element.scrollLeft + OFFSET_WIDTH : element.scrollLeft - OFFSET_WIDTH;
@@ -80,6 +80,9 @@ const { state } = store( 'wporg/themes/style-variations', {
 			} );
 		},
 		handleNext() {
+			if ( ! state.canNext ) {
+				return;
+			}
 			const { isRTL } = getContext();
 			const element = getRowElement( getElement().ref );
 			const position = isRTL ? element.scrollLeft - OFFSET_WIDTH : element.scrollLeft + OFFSET_WIDTH;


### PR DESCRIPTION
Fixes the Style Variations carousel on theme pages keeping its prev/next arrows enabled and clickable when there is no additional content to scroll to, at both the beginning and the end of the carousel.

Fixes https://meta.trac.wordpress.org/ticket/8373.

## Root cause

Reproduced on https://wordpress.org/themes/salecraft-ecommerce/: with the carousel scrolled fully to the end, `scrollLeft` rested at `752.5` while the computed overflow was `753`, so `state.canNext` (`position < overflow`) stayed `true` and the next arrow never disabled. Several issues compound here:

1. **Exact comparisons vs. fractional scroll positions.** `canPrevious`/`canNext` compared `scrollLeft` against the exact overflow value. On zoomed or high-DPI displays `scrollLeft` is fractional and never exactly reaches that value, so the arrows stayed enabled at the ends.
2. **Brittle overflow calculation.** The scrollable overflow was reconstructed from the `--wporg-theme-style-variations--size` custom property and `parseInt`-ed `gap`, which can drift from the real scroll range.
3. **RTL off-by-one.** In RTL, `canNext` used `>=`, which kept the arrow enabled even at the exact end position.
4. **`aria-disabled` didn't prevent interaction.** Even when the state was computed correctly, the "disabled" arrow kept `cursor: pointer` and still ran its click handler.

## Changes

* Compare scroll positions with a 1px tolerance (`SCROLL_TOLERANCE`) via a sign-normalizing `scrolled` getter, which also fixes the RTL end comparison.
* Compute the overflow as `scrollWidth - clientWidth` instead of deriving it from CSS values.
* Ignore pointer events on disabled arrows (same pattern as `theme-settings`), and bail early in `handlePrevious`/`handleNext` so keyboard activation is a no-op as well. Because clicks on a disabled arrow then fall through to the buttons container, the container opts out of text selection (`user-select: none`) — otherwise rapid clicks would start a selection across the style variation thumbnails.

* Fix the forward arrow icon shifting 1px on keyboard focus: the theme's button focus style trades the 1px border for 1px of padding on all sides, but the forward button has no left border to trade, so its left padding is pinned on focus.

* Fix the arrow group never actually hiding on themes whose variations don't overflow: the container's `display: flex` overrode the UA style for the `hidden` attribute that `data-wp-bind--hidden` sets.

## Testing

* Verified in the local Theme Directory environment (`environments/theme-directory/`) on the `extendable` theme (44 variations): the back arrow is disabled at the start, the forward arrow disables at the exact end position, each re-enables when scrolling away, the arrow group is `display: none` on twentytwentytwo (4 variations, no overflow), and rapid clicks on a disabled arrow do nothing — no scroll, no focus ring, no text selection.
* `npm run build:theme` compiles, `lint-style` passes (ESLint currently fails to load its shared config on trunk, unrelated to this change).
* Verified the old logic fails and the new logic passes a 10-case matrix (LTR/RTL × start/middle/end × integer/fractional positions, plus the no-overflow case), including the exact `752.5/753` values from the reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

