### PR TITLE
Improve PHP 8+ Compatibility, Accessibility, Functionality, and Input…

### DIFF
--- a/source/wp-content/plugins/wporg-ratings/wporg-ratings.php
+++ b/source/wp-content/plugins/wporg-ratings/wporg-ratings.php
@@ -93,7 +93,7 @@ class WPORG_Ratings {
 	 * @param $user_id id of users' rating.
 	 * @param $rating the rating being set.
 	 */
-	public static function set_rating( $post_id = 0, $object_type, $object_slug, $user_id, $rating ) {
+	public static function set_rating( int $post_id, string $object_type, string $object_slug, int $user_id, int $rating ) {
 		global $wpdb;
 
 		// Make sure the current user has permissions to submit the rating.

--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -135,7 +135,7 @@ function enqueue_assets() {
  */
 function post_thumbnail_html( $html, $post_id, $post_thumbnail_id, $size, $attr ) {
 	$current_post = get_post( $post_id );
-	if ( THEME_POST_TYPE == $current_post->post_type ) {
+	if ( $current_post && THEME_POST_TYPE === $current_post->post_type ) {
 		$theme = new \WPORG_Themes_Repo_Package( $current_post );
 		$src   = add_query_arg(
 			array(
@@ -156,7 +156,7 @@ function post_thumbnail_html( $html, $post_id, $post_thumbnail_id, $size, $attr 
 		}
 
 		$html .= ' />';
-	} else if ( 'theme_shop' == $current_post->post_type ) {
+	} else if ( $current_post && 'theme_shop' === $current_post->post_type ) {
 		$src = get_post_meta( $current_post->ID, 'image_url', true );
 		if ( ! $src ) {
 			$url = get_post_meta( $current_post->ID, 'url', true );
@@ -274,7 +274,7 @@ function modify_query_loop_block_query_vars( $query, $block ) {
  * @param WP_Post $post      The post in question.
  */
 function update_theme_shop_permalink( $post_link, $post ) {
-	if ( 'theme_shop' === $post->post_type ) {
+	if ( $post && 'theme_shop' === $post->post_type ) {
 		$url = get_post_meta( $post->ID, 'url', true );
 		if ( $url ) {
 			$post_link = $url;
@@ -603,9 +603,13 @@ function get_theme_style_variations( $post ) {
  */
 function update_cached_style_variations( $post_id ) {
 	$post = get_post( $post_id );
+	if ( ! $post || ! ( $post instanceof \WP_Post ) ) {
+		return [];
+	}
 
 	// If the postmeta doesn't yet exist, set it to empty for other requests.
-	if ( ! is_array( $post->style_variations ) ) {
+	$existing = get_post_meta( $post_id, 'style_variations', true );
+	if ( ! is_array( $existing ) ) {
 		update_post_meta( $post_id, 'style_variations', [] );
 	}
 
@@ -614,7 +618,7 @@ function update_cached_style_variations( $post_id ) {
 	$url = add_query_arg( 'rest_route', '/wporg-styles/v2/variations', $url );
 	$response = wp_remote_get( $url );
 	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		return;
+		return [];
 	}
 
 	$styles = json_decode( wp_remote_retrieve_body( $response ) );
@@ -637,9 +641,13 @@ function update_cached_style_variations( $post_id ) {
  */
 function update_cached_theme_patterns( $post_id ) {
 	$post = get_post( $post_id );
+	if ( ! $post || ! ( $post instanceof \WP_Post ) ) {
+		return [];
+	}
 
 	// If the postmeta doesn't yet exist, set it to empty for other requests.
-	if ( ! is_array( $post->theme_patterns ) ) {
+	$existing = get_post_meta( $post_id, 'theme_patterns', true );
+	if ( ! is_array( $existing ) ) {
 		update_post_meta( $post_id, 'theme_patterns', [] );
 	}
 
@@ -648,7 +656,7 @@ function update_cached_theme_patterns( $post_id ) {
 	$url = add_query_arg( 'rest_route', '/wporg-patterns/v2/patterns', $url );
 	$response = wp_remote_get( $url );
 	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		return;
+		return [];
 	}
 
 	$patterns = json_decode( wp_remote_retrieve_body( $response ) );

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-bindings.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-bindings.php
@@ -34,9 +34,13 @@ function get_meta_block_value( $args, $block ) {
 		return '';
 	}
 
-	$p = get_post( $block->context['postId'] );
+	$p = get_post( $block->context['postId'] ?? null );
+	if ( ! $p || ! ( $p instanceof \WP_Post ) ) {
+		return '';
+	}
+
 	$theme = wporg_themes_theme_information( $p->post_name );
-	if ( isset( $theme->error ) ) {
+	if ( ! $theme || isset( $theme->error ) ) {
 		return '';
 	}
 

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
@@ -308,8 +308,9 @@ function inject_language_suggest_endpoint( $block_content ) {
 	$html = new WP_HTML_Tag_Processor( $block_content );
 	$html->next_tag();
 	$endpoint_url = rest_url( '/wporg-themes/v1/locale-banner/' );
-	if ( is_single() ) {
-		$endpoint_url = trailingslashit( $endpoint_url . get_queried_object()->post_name );
+	$queried = get_queried_object();
+	if ( is_single() && $queried && isset( $queried->post_name ) ) {
+		$endpoint_url = trailingslashit( $endpoint_url . $queried->post_name );
 	}
 	$html->set_attribute( 'data-endpoint', $endpoint_url );
 	return $html->get_updated_html();

--- a/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/i18n.php
@@ -63,7 +63,7 @@ function translate_the_title( $title, $post_id = null ) {
  * @param WP_Term $term The WP_Term object being loaded.
  */
 function translate_term( $term ) {
-	if ( is_admin() || 'post_tag' !== $term->taxonomy ) {
+	if ( is_admin() || ! ( $term instanceof \WP_Term ) || 'post_tag' !== $term->taxonomy ) {
 		return $term;
 	}
 

--- a/source/wp-content/themes/wporg-themes-2024/inc/seo-social-meta.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/seo-social-meta.php
@@ -81,6 +81,8 @@ function document_title_separator() {
  * Add meta tags for richer social media integrations.
  */
 function add_social_meta_tags( $tags ) {
+	global $wp_query;
+
 	$default_image = 'https://wordpress.org/files/2024/06/wporg-themes-ogimage-2024.png';
 	$site_title = function_exists( '\WordPressdotorg\site_brand' ) ? \WordPressdotorg\site_brand() : 'WordPress.org';
 	$description = __( 'Find the perfect theme for your WordPress website. Choose from thousands of stunning designs with a wide variety of features and customization options.', 'wporg-themes' );

--- a/source/wp-content/themes/wporg-themes-2024/src/business-model-notice/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/business-model-notice/index.php
@@ -39,6 +39,9 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$theme_post = get_post( $block->context['postId'] );
+	if ( ! $theme_post || ! ( $theme_post instanceof \WP_Post ) ) {
+		return '';
+	}
 
 	$is_commercial = has_term( 'commercial', 'theme_business_model', $theme_post );
 	$is_community = has_term( 'community', 'theme_business_model', $theme_post );
@@ -72,7 +75,7 @@ function render( $attributes, $content, $block ) {
 	$markup .= '<!-- wp:paragraph --><p>';
 	$markup .= esc_html( $content );
 	if ( $url ) {
-		$markup .= ' <a href="' . esc_url( $url ) . '" class="external-link">' . esc_html( $link_text ) . '</a>'; //nofollow
+		$markup .= ' <a href="' . esc_url( $url ) . '" class="external-link" rel="nofollow noopener">' . esc_html( $link_text ) . '</a>';
 	}
 	$markup .= '</p><!-- /wp:paragraph -->';
 

--- a/source/wp-content/themes/wporg-themes-2024/src/child-theme-notice/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/child-theme-notice/index.php
@@ -39,7 +39,14 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$theme_post = get_post( $block->context['postId'] );
+	if ( ! $theme_post || ! ( $theme_post instanceof \WP_Post ) ) {
+		return '';
+	}
+
 	$theme = wporg_themes_theme_information( $theme_post->post_name );
+	if ( ! $theme || isset( $theme->error ) ) {
+		return '';
+	}
 
 	if ( empty( $theme->parent ) ) {
 		return '';

--- a/source/wp-content/themes/wporg-themes-2024/src/meta-list/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/meta-list/index.php
@@ -82,7 +82,7 @@ function render( $attributes, $content, $block ) {
 			if ( 'theme-link' === $field['key'] ) {
 				$list_items[] = sprintf(
 					'<li class="is-meta-%1$s">
-						<a href="%2$s" class="external-link">%3$s</a>
+						<a href="%2$s" class="external-link" rel="noopener noreferrer">%3$s</a>
 					</li>',
 					$field['key'],
 					esc_url( $value ),
@@ -122,19 +122,23 @@ function render( $attributes, $content, $block ) {
  */
 function get_value( $key, $post_id ) {
 	$p = get_post( $post_id );
+	if ( ! $p || ! ( $p instanceof \WP_Post ) ) {
+		return '';
+	}
+
 	$theme = wporg_themes_theme_information( $p->post_name );
-	if ( isset( $theme->error ) ) {
+	if ( ! $theme || isset( $theme->error ) ) {
 		return '';
 	}
 
 	switch ( $key ) {
 		case 'version':
-			return $theme->version;
+			return $theme->version ?? '';
 		case 'last-updated':
 			/* translators: localized date format, see http://php.net/date */
 			return date_i18n( _x( 'F j, Y', 'last update date format', 'wporg-themes' ), strtotime( $theme->last_updated ) );
 		case 'active-installs':
-			$active_installs = $theme->active_installs;
+			$active_installs = $theme->active_installs ?? 0;
 			if ( $active_installs < 10 ) {
 				$active_installs = __( 'Less than 10', 'wporg-themes' );
 			} elseif ( $active_installs >= 1000000 ) {
@@ -160,9 +164,5 @@ function get_value( $key, $post_id ) {
 			return '';
 	}
 
-	if ( is_wp_error( $value ) ) {
-		return '';
-	}
-
-	return $value;
+	return '';
 }

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-available-translations/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-available-translations/index.php
@@ -41,8 +41,12 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$theme_post = get_post( $block->context['postId'] );
+	if ( ! $theme_post || ! ( $theme_post instanceof \WP_Post ) ) {
+		return '';
+	}
+
 	$theme = wporg_themes_theme_information( $theme_post->post_name );
-	if ( isset( $theme->error ) ) {
+	if ( ! $theme || isset( $theme->error ) ) {
 		return '';
 	}
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-downloads/index.php
@@ -41,8 +41,12 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$theme_post = get_post( $block->context['postId'] );
+	if ( ! $theme_post || ! ( $theme_post instanceof \WP_Post ) ) {
+		return '';
+	}
+
 	$theme = wporg_themes_theme_information( $theme_post->post_name );
-	if ( isset( $theme->error ) ) {
+	if ( ! $theme || isset( $theme->error ) ) {
 		return '';
 	}
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/render.php
@@ -11,6 +11,10 @@ if ( ! $current_post_id ) {
 $show_all = $attributes['showAll'] ?? false;
 
 $theme_post = get_post( $block->context['postId'] );
+if ( ! $theme_post || ! ( $theme_post instanceof \WP_Post ) ) {
+	return '';
+}
+
 $theme = wporg_themes_theme_information( $theme_post->post_name );
 
 $patterns = get_theme_patterns( $theme_post );
@@ -22,9 +26,10 @@ if ( ! $pattern_count ) {
 }
 
 $selected_index = -1;
-if ( isset( $_GET['pattern_name'] ) ) {
+if ( isset( $_GET['pattern_name'] ) && is_string( $_GET['pattern_name'] ) ) {
+	$requested_pattern = wp_unslash( $_GET['pattern_name'] );
 	foreach ( $patterns as $i => $pattern ) {
-		if ( $pattern->name === $_GET['pattern_name'] ) {
+		if ( $pattern->name === $requested_pattern ) {
 			$selected_index = $i;
 			break;
 		}

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/iframe/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/iframe/render.php
@@ -10,6 +10,10 @@ if ( ! $current_post_id ) {
 $is_playground = ! empty( $_REQUEST['playground-preview'] );
 
 $theme_post = get_post( $block->context['postId'] );
+if ( ! $theme_post || ! ( $theme_post instanceof \WP_Post ) ) {
+	return;
+}
+
 $theme = wporg_themes_theme_information( $theme_post->post_name );
 
 // Get the device size from the query.
@@ -41,7 +45,7 @@ $encoded_state = wp_json_encode( $init_state );
 				data-device="desktop"
 			>
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" aria-hidden="true" focusable="false"><path d="M20.5 16h-.7V8c0-1.1-.9-2-2-2H6.2c-1.1 0-2 .9-2 2v8h-.7c-.8 0-1.5.7-1.5 1.5h20c0-.8-.7-1.5-1.5-1.5zM5.7 8c0-.3.2-.5.5-.5h11.6c.3 0 .5.2.5.5v7.6H5.7V8z"></path></svg>
-				<span><?php echo esc_attr_x( 'Wide', 'theme preview size toggle', 'wporg-themes' ); ?></span>
+				<span><?php echo esc_html_x( 'Wide', 'theme preview size toggle', 'wporg-themes' ); ?></span>
 			</button>
 		</div>
 		<div class="wp-block-button is-style-toggle is-small">
@@ -52,7 +56,7 @@ $encoded_state = wp_json_encode( $init_state );
 				data-device="tablet"
 			>
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" aria-hidden="true" focusable="false"><path d="M17 4H7c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 14c0 .3-.2.5-.5.5H7c-.3 0-.5-.2-.5-.5V6c0-.3.2-.5.5-.5h10c.3 0 .5.2.5.5v12zm-7.5-.5h4V16h-4v1.5z"></path></svg>
-				<span><?php echo esc_attr_x( 'Medium', 'theme preview size toggle', 'wporg-themes' ); ?></span>
+				<span><?php echo esc_html_x( 'Medium', 'theme preview size toggle', 'wporg-themes' ); ?></span>
 			</button>
 		</div>
 		<div class="wp-block-button is-style-toggle is-small">
@@ -63,12 +67,12 @@ $encoded_state = wp_json_encode( $init_state );
 				data-device="mobile"
 			>
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" aria-hidden="true" focusable="false"><path d="M15 4H9c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h6c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 14c0 .3-.2.5-.5.5H9c-.3 0-.5-.2-.5-.5V6c0-.3.2-.5.5-.5h6c.3 0 .5.2.5.5v12zm-4.5-.5h2V16h-2v1.5z"></path></svg>
-				<span><?php echo esc_attr_x( 'Narrow', 'theme preview size toggle', 'wporg-themes' ); ?></span>
+				<span><?php echo esc_html_x( 'Narrow', 'theme preview size toggle', 'wporg-themes' ); ?></span>
 			</button>
 		</div>
 	</section>
 	<iframe
-		title="<?php esc_attr_e( 'Theme preview', 'wporg-themes' ); ?>"
+		title="<?php echo esc_attr( sprintf( __( 'Theme preview for %s', 'wporg-themes' ), $theme->name ?? '' ) ); ?>"
 		data-wp-style--width="state.iframeWidthCSS"
 		data-wp-style--height="state.iframeHeightCSS"
 		<?php if ( $is_playground ) { ?>
@@ -78,5 +82,5 @@ $encoded_state = wp_json_encode( $init_state );
 			data-wp-bind--src="wporg/themes/preview::context.url"
 			data-wp-on--load="wporg/themes/preview::actions.onLoad"
 		<?php } ?>
-	/>
+	></iframe>
 </div>

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-previewer/render.php
@@ -13,7 +13,14 @@ wp_enqueue_script( 'wp-a11y' );
 $is_playground = ! empty( $_REQUEST['playground-preview'] );
 
 $theme_post = get_post( $block->context['postId'] );
+if ( ! $theme_post || ! ( $theme_post instanceof \WP_Post ) ) {
+	return;
+}
+
 $theme = wporg_themes_theme_information( $theme_post->post_name );
+if ( ! $theme || isset( $theme->error ) ) {
+	return;
+}
 
 $url = $theme->preview_url ?? '';
 $permalink = get_permalink() . 'preview/';

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-settings/render.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-settings/render.php
@@ -5,6 +5,9 @@ if ( ! $block->context['postId'] ) {
 }
 
 $theme_post = get_post( $block->context['postId'] );
+if ( ! $theme_post || ! ( $theme_post instanceof \WP_Post ) ) {
+	return '';
+}
 
 $model_type = false;
 $url = '';

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-status-notice/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-status-notice/index.php
@@ -39,7 +39,14 @@ function render( $attributes, $content, $block ) {
 	}
 
 	$theme_post = get_post( $block->context['postId'] );
+	if ( ! $theme_post || ! ( $theme_post instanceof \WP_Post ) ) {
+		return '';
+	}
+
 	$theme = wporg_themes_theme_information( $theme_post->post_name );
+	if ( ! $theme || isset( $theme->error ) || empty( $theme->last_updated ) ) {
+		return '';
+	}
 
 	if ( time() - strtotime( $theme->last_updated ) <= 2 * YEAR_IN_SECONDS ) {
 		return '';


### PR DESCRIPTION
PHP 8+ Compatibility, Null Safety, Accessibility & Security Checks

Add input/type hints, null checks and instance validation across the plugin and theme to avoid notices and harden data handling. Key changes: typed parameters in wporg-ratings, guard clauses for get_post/get_queried_object and WP_Post/WP_Term checks, sanitize/validate $_GET input, fetch existing postmeta before initializing, return empty arrays on failed remote requests, switch to esc_html_x for visible preview labels, properly close iframe and improve link rel attributes (nofollow/noopener, noopener noreferrer). These changes improve stability, security and accessibility.

### Description

This Pull Request addresses PHP 8+ compatibility warnings, potential runtime fatal errors, accessibility issues, and security enhancements across `wporg-ratings` and `wporg-themes-2024`:

1. **PHP 8+ Deprecation & Type Safety**:
   - Resolved deprecated optional parameter order in `WPORG_Ratings::set_rating()` where `$post_id = 0` was declared before required parameters. Added type declarations (`int $post_id`, `string $object_type`, `string $object_slug`, `int $user_id`, `int $rating`).
   - Added guard clauses checking `get_post()` and `get_queried_object()` for `WP_Post` instances to prevent null-pointer dereferences in PHP 8.0+.
   - Added `WP_Term` instance check in `translate_term()` before reading properties.
   - Declared `global $wp_query;` inside `add_social_meta_tags()` to fix undefined variable warning.
   - Fixed uninitialized `$value` check in `Meta_List\get_value()`.
   - Updated `update_cached_style_variations()` and `update_cached_theme_patterns()` to fetch existing postmeta before initializing and return `[]` on HTTP error / empty payload.

2. **Input Sanitization**:
   - Sanitized and type-validated `$_GET['pattern_name']` using `is_string()` and `wp_unslash()`.

3. **Accessibility & Standards**:
   - Switched `esc_attr_x()` to `esc_html_x()` for HTML button text node content in `src/theme-previewer/iframe/render.php`.
   - Properly closed self-closing `<iframe ... />` tag with `<iframe ...></iframe>`.
   - Enhanced `<iframe>` title attribute to include theme name for screen readers.

4. **Link Security**:
   - Added `rel="nofollow noopener"` to external support/repo link in `business-model-notice/index.php`.
   - Added `rel="noopener noreferrer"` to external theme link in `meta-list/index.php`.

Fixes #, See #.

Props <username>, <username>

### Screenshots

| Before | After |
|--------|-------|
| N/A | N/A |

### How to test the changes in this Pull Request:

1. **PHP 8+ Compatibility Linting**:
   - Run `find source extra -name "*.php" -exec php -l {} +` using PHP 8.1+ / PHP 8.5+.
   - Confirm 0 syntax errors and 0 deprecation warnings occur.

2. **Null Safety & Block Rendering**:
   - View single theme pages, community theme pages, commercial theme pages, author pages, and invalid/missing post ID contexts.
   - Verify all block renderers (`theme-previewer`, `theme-patterns`, `theme-settings`, `theme-downloads`, `business-model-notice`, `child-theme-notice`, `theme-status-notice`, `theme-available-translations`, `meta-list`) render without throwing PHP notices or Fatal Errors when post objects are null or unavailable.

3. **Accessibility & Link Attributes**:
   - Inspect the device size toggle buttons in the theme previewer iframe and verify text labels render cleanly.
   - Inspect the preview iframe markup and verify proper closing tag `</iframe>` and accessible title.
   - Check external theme links and external support links to ensure `rel="nofollow noopener"` and `rel="noopener noreferrer"` attributes are present.