### PR TITLE
Themes: Escape attributes in the screenshot markup and block delimiters

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/functions.php
+++ b/source/wp-content/themes/wporg-themes-2024/functions.php
@@ -151,7 +151,7 @@ function post_thumbnail_html( $html, $post_id, $post_thumbnail_id, $size, $attr 
 			$attr['alt'] = '';
 
 			foreach ( $attr as $name => $value ) {
-				$html .= " $name=" . '"' . $value . '"';
+				$html .= sprintf( ' %s="%s"', esc_attr( $name ), esc_attr( $value ) );
 			}
 		}
 
@@ -182,7 +182,7 @@ function post_thumbnail_html( $html, $post_id, $post_thumbnail_id, $size, $attr 
 			$attr['alt'] = '';
 
 			foreach ( $attr as $name => $value ) {
-				$html .= " $name=" . '"' . $value . '"';
+				$html .= sprintf( ' %s="%s"', esc_attr( $name ), esc_attr( $value ) );
 			}
 		}
 

--- a/source/wp-content/themes/wporg-themes-2024/inc/embed.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/embed.php
@@ -86,7 +86,7 @@ function update_embed_thumbnail( $html, $attachment_id, $size, $icon, $attr ) {
 			$attr['alt'] = '';
 
 			foreach ( $attr as $name => $value ) {
-				$html .= " $name=" . '"' . $value . '"';
+				$html .= sprintf( ' %s="%s"', esc_attr( $name ), esc_attr( $value ) );
 			}
 		}
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-patterns/index.php
@@ -37,7 +37,7 @@ function get_pattern_preview_block( $pattern, $is_overflow = false, $is_selected
 		'isHidden' => $is_overflow,
 	);
 
-	$image_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', wp_json_encode( $args ) ) );
+	$image_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', serialize_block_attributes( $args ) ) );
 
 	$instance_id = wp_unique_id( 'wporg-theme-patterns-item-' );
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations-items/index.php
@@ -34,7 +34,7 @@ function get_style_variation_card( $style, $is_selected = false ) {
 		'viewportHeight' => 740,
 		'fullPage' => false,
 	);
-	$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', wp_json_encode( $args ) ) );
+	$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', serialize_block_attributes( $args ) ) );
 
 	$instance_id = wp_unique_id( 'wporg-theme-style-var-item-' );
 

--- a/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
+++ b/source/wp-content/themes/wporg-themes-2024/src/theme-style-variations/index.php
@@ -44,7 +44,7 @@ function get_style_variation_card( $style ) {
 		'viewportHeight' => 740,
 		'fullPage' => false,
 	);
-	$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', wp_json_encode( $args ) ) );
+	$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', serialize_block_attributes( $args ) ) );
 
 	$html = new WP_HTML_Tag_Processor( $block_markup );
 	$html->next_tag( 'a' );
@@ -70,7 +70,7 @@ function get_theme_preview_images( $theme_post ) {
 				'src' => $style->link,
 				'fullPage' => false,
 			);
-			$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', wp_json_encode( $args ) ) );
+			$block_markup = do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', serialize_block_attributes( $args ) ) );
 		}
 
 		$context = wp_json_encode( array( 'style' => strtolower( $style->title ) ) );


### PR DESCRIPTION
Two related output-escaping problems in the theme screenshot paths.

## 1. The `post_thumbnail_html` attribute loop

`post_thumbnail_html()` re-implements core's `wp_get_attachment_image()` emission loop, but without its escaping step. Core does:

```php
$attr = array_map( 'esc_attr', $attr );
foreach ( $attr as $name => $value ) {
	$html .= " $name=" . '"' . $value . '"';
}
```

The theme kept the loop and dropped the `array_map`, so both the attribute **name** and the **value** are emitted raw.

`$attr` is not internal state — it is the third argument of `get_the_post_thumbnail()`, and core's `core/post-featured-image` block builds it from block attributes by string interpolation (`$extra_styles .= "height:{$attributes['height']};"`). Core is holding up its end: it hands `$attr` to a function contractually required to escape it, and core's own implementation does.

Worth noting the `src` on the line directly above *is* `esc_url()`ed — the tell that the loop was overlooked rather than deliberately trusted. `theme-directory`'s own `wporg_themes_post_thumbnail_html()` implements the same filter correctly by building a fixed tag and discarding `$attr` entirely, so this is an outlier rather than the house style.

Fixed in all three copies — the `THEME_POST_TYPE` branch, the `theme_shop` branch, and `update_embed_thumbnail()` in `inc/embed.php`.

## 2. Block delimiters built with `wp_json_encode()`

The pattern and style-variation cards build block markup like this:

```php
do_blocks( sprintf( '<!-- wp:wporg/screenshot-preview %s /-->', wp_json_encode( $args ) ) );
```

`wp_json_encode()` with flags `0` escapes `"` and `\`, but not `<`, `>` or `-`. Core's block tokeniser ends the attribute JSON at the first `}` followed by whitespace and `-->`:

```
(?P<attrs>{(?:(?!}\s+\/?-->).)*?}\s+)?(?P<void>\/)?-->
```

So a value containing `} -->` closes the delimiter, and everything after it is parsed as sibling block markup.

Core has a function built for exactly this position — `serialize_block_attributes()` — which additionally escapes `--`, `<`, `>`, `&` and `\"`. Swapped in at all four sites (`theme-patterns`, `theme-style-variations` ×2, `theme-style-variations-items`).

**No behaviour change for valid input.** The escapes are unicode sequences that `json_decode()` reverses, so attributes arrive at the render callback identical to before. Checked against core's own tokeniser regex with a value containing `} -->`:

```
before: delimiter ends at 88 of 167 chars; tail escaping into sibling markup =
        "<!-- wp:html --><img src=x onerror=alert(1)>\",\"width\":275,...} \/-->"
after:  delimiter ends at 219 of 219 chars; tail = (none)
```

and a benign value carrying `&`, an em dash and accented characters round-trips byte-identically through `json_decode()`.

## Notes

- `build/` is gitignored and only carries `render.php` / `block.json` / assets; every file changed here is a `src/*/index.php` that is `require_once`d directly from `functions.php`, so there is nothing to rebuild.
- Not included, as a possible follow-up: `update_cached_theme_patterns()` stores the wp-themes.com pattern metadata with `json_decode()` → `update_post_meta()` and no validation. Sanitising `title` / `description` and `esc_url_raw()`-ing the links on ingest would harden the storage side, but the sinks above are the actual fix and have to be safe regardless of what is already stored.
- `./vendor/bin/phpcs` passes clean on all five changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)