### PR TITLE
Themes: supply the language suggestion endpoint through a filter

### DIFF
--- a/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
@@ -18,8 +18,8 @@ add_action( 'wporg_query_filter_in_form', __NAMESPACE__ . '\inject_other_filters
 add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
 add_filter( 'wporg_favorite_button_settings', __NAMESPACE__ . '\get_favorite_settings', 10, 2 );
 add_filter( 'wporg_ratings_data', __NAMESPACE__ . '\set_rating_data', 10, 2 );
+add_filter( 'wporg_language_suggest_endpoint', __NAMESPACE__ . '\get_language_suggest_endpoint' );
 add_filter( 'render_block_wporg/link-wrapper', __NAMESPACE__ . '\inject_permalink_link_wrapper' );
-add_filter( 'render_block_wporg/language-suggest', __NAMESPACE__ . '\inject_language_suggest_endpoint' );
 add_filter( 'render_block_core/search', __NAMESPACE__ . '\inject_browse_search_block' );
 add_filter( 'render_block_core/query-title', __NAMESPACE__ . '\update_archive_title', 10, 3 );
 add_filter( 'render_block_wporg/language-suggest', __NAMESPACE__ . '\filter_language_suggest_block' );
@@ -300,19 +300,22 @@ function inject_permalink_link_wrapper( $block_content ) {
 /**
  * Update the endpoint used in `wporg/language-suggest` for the current theme.
  *
- * @param string $block_content The block content.
+ * The block resolves its endpoint server-side rather than from a `data-endpoint`
+ * attribute, so that block markup in post content cannot choose where the
+ * suggestion is fetched from.
  *
- * @return array The updated block.
+ * @param string $endpoint The default endpoint URL.
+ *
+ * @return string The endpoint URL for the current request.
  */
-function inject_language_suggest_endpoint( $block_content ) {
-	$html = new WP_HTML_Tag_Processor( $block_content );
-	$html->next_tag();
-	$endpoint_url = rest_url( '/wporg-themes/v1/locale-banner/' );
+function get_language_suggest_endpoint( $endpoint ) {
+	$endpoint = rest_url( '/wporg-themes/v1/locale-banner/' );
+
 	if ( is_single() ) {
-		$endpoint_url = trailingslashit( $endpoint_url . get_queried_object()->post_name );
+		$endpoint = trailingslashit( $endpoint . get_queried_object()->post_name );
 	}
-	$html->set_attribute( 'data-endpoint', $endpoint_url );
-	return $html->get_updated_html();
+
+	return $endpoint;
 }
 
 /**

--- a/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
+++ b/source/wp-content/themes/wporg-themes-2024/inc/block-config.php
@@ -300,10 +300,6 @@ function inject_permalink_link_wrapper( $block_content ) {
 /**
  * Update the endpoint used in `wporg/language-suggest` for the current theme.
  *
- * The block resolves its endpoint server-side rather than from a `data-endpoint`
- * attribute, so that block markup in post content cannot choose where the
- * suggestion is fetched from.
- *
  * @param string $endpoint The default endpoint URL.
  *
  * @return string The endpoint URL for the current request.


### PR DESCRIPTION
Companion to WordPress/wporg-mu-plugins#764, which moves the Language Suggest block's endpoint resolution from a `data-endpoint` attribute to a `wporg_language_suggest_endpoint` filter.

### Changes

`inc/block-config.php` — `inject_language_suggest_endpoint()` becomes `get_language_suggest_endpoint()` and hooks the new filter instead of `render_block_wporg/language-suggest`. It no longer needs `WP_HTML_Tag_Processor` to rewrite the block's markup; it just returns the URL. The `is_single()` slug logic carries over unchanged.

`filter_language_suggest_block()`, which adds the prominent style on single theme views, is untouched and stays on `render_block`.

### Result

Theme pages currently fall back to the network-wide suggestion:

| | Now | With this change |
|---|---|---|
| `/themes/twentytwentyfour/` | WordPress ist auch auf Deutsch verfügbar. | Dieses Theme ist auch auf Deutsch verfügbar. Hilf mit, die Übersetzung zu verbessern. |
| `/themes/` | WordPress ist auch auf Deutsch verfügbar. | Das Theme-Verzeichnis ist auch auf Deutsch verfügbar. |

### Ordering

Needs WordPress/wporg-mu-plugins#764 deployed for the filter to exist. Landing in either order is safe — until both are out, the pages show the network-wide notice, which is where they already are.

WordPress/wordpress.org#839 has the equivalent change for the plugin directory.

### One thing worth checking

`trunk` still injects `data-endpoint`, but production currently serves theme pages without it, while still applying `is-style-prominent` from the other filter registered on the same hook two lines below. So the endpoint filter specifically is not running in production, and no commit on trunk removes it. Might be deploy lag, might be an out-of-band patch — worth a look from someone with visibility into how this theme is deployed, since it affects whether this is a fix or a no-op there.

### Testing

`php -l` and phpcs clean on the changed file. `rest_url( '/wporg-themes/v1/locale-banner/' )` plus the slug returns the same URL the attribute previously carried, verified against the live endpoint for both the single-theme and archive cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)